### PR TITLE
fix: encode and decode message types

### DIFF
--- a/src/nexus/asgi.py
+++ b/src/nexus/asgi.py
@@ -143,7 +143,7 @@ class ASGIServer:
             return
 
         await dispatcher.dispatch(
-            env.sender, env.target, env.protocol, json.dumps(env.decode_payload())
+            env.sender, env.target, env.protocol, env.decode_payload()
         )
 
         # wait for any queries to be resolved

--- a/src/nexus/context.py
+++ b/src/nexus/context.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import uuid
 from dataclasses import dataclass
@@ -106,7 +105,7 @@ class Context:
         # handle local dispatch of messages
         if dispatcher.contains(destination):
             await dispatcher.dispatch(
-                self.address, destination, schema_digest, json.dumps(json_message)
+                self.address, destination, schema_digest, json_message
             )
             return
 

--- a/src/nexus/envelope.py
+++ b/src/nexus/envelope.py
@@ -1,12 +1,12 @@
 import base64
 import hashlib
-import json
 import struct
 from typing import Optional, Any
 
 from pydantic import BaseModel, UUID4
 
 from nexus.crypto import Identity
+from nexus.dispatch import JsonStr
 
 
 class Envelope(BaseModel):
@@ -19,14 +19,14 @@ class Envelope(BaseModel):
     expires: Optional[int] = None
     signature: Optional[str] = None
 
-    def encode_payload(self, value: Any):
-        self.payload = base64.b64encode(json.dumps(value).encode()).decode()
+    def encode_payload(self, value: JsonStr):
+        self.payload = base64.b64encode(value.encode()).decode()
 
     def decode_payload(self) -> Optional[Any]:
         if self.payload is None:
             return None
 
-        return json.loads(base64.b64decode(self.payload).decode())
+        return base64.b64decode(self.payload).decode()
 
     def sign(self, identity: Identity):
         self.signature = identity.sign_digest(self._digest())

--- a/src/nexus/query.py
+++ b/src/nexus/query.py
@@ -73,5 +73,5 @@ def enclose_response(message: Model, sender: str, session: str) -> dict:
         session=session,
         protocol=Model.build_schema_digest(message),
     )
-    response_env.encode_payload(message.dict())
+    response_env.encode_payload(message.json())
     return response_env.json()


### PR DESCRIPTION
Messages should be encoded, decoded, and put into the queue as Json strings, not dicts.