### PR TITLE
refactor: ensure startup tasks occur before interval tasks

### DIFF
--- a/src/uagents/protocol.py
+++ b/src/uagents/protocol.py
@@ -13,7 +13,7 @@ OPENAPI_VERSION = "3.0.2"
 
 class Protocol:
     def __init__(self, name: Optional[str] = None, version: Optional[str] = None):
-        self._intervals: List[Tuple[IntervalCallback, float]] = []
+        self._interval_handlers: List[Tuple[IntervalCallback, float]] = []
         self._interval_messages: Set[str] = set()
         self._signed_message_handlers: Dict[str, MessageCallback] = {}
         self._unsigned_message_handlers: Dict[str, MessageCallback] = {}
@@ -32,7 +32,7 @@ class Protocol:
 
     @property
     def intervals(self):
-        return self._intervals
+        return self._interval_handlers
 
     @property
     def models(self):
@@ -92,7 +92,7 @@ class Protocol:
     ):
 
         # store the interval handler for later
-        self._intervals.append((func, period))
+        self._interval_handlers.append((func, period))
 
         # if message types are specified, store these for validation
         if messages is not None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -38,7 +38,7 @@ class TestAgent(unittest.TestCase):
         def _(_ctx):
             pass
 
-        interval = self.agent._protocol._intervals[0]
+        interval = self.agent._protocol._interval_handlers[0]
         self.assertTrue(isinstance(interval[0], Callable))
         self.assertEqual(interval[1], 10)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -37,7 +37,7 @@ class TestAgent(unittest.TestCase):
         def _(_ctx):
             pass
 
-        interval = self.protocol._intervals[0]
+        interval = self.protocol._interval_handlers[0]
         self.assertTrue(isinstance(interval[0], Callable))
         self.assertEqual(interval[1], 10)
 


### PR DESCRIPTION
Previously, interval tasks were being created on protocol inclusion, but now these are added along with the other background tasks, after the startup handlers are executed.