### PR TITLE
feat: bureau overwrites agent endpoints

### DIFF
--- a/src/uagents/agent.py
+++ b/src/uagents/agent.py
@@ -429,7 +429,7 @@ class Bureau:
     def __init__(
         self,
         port: Optional[int] = None,
-        endpoint: Optional[Union[List[str], Dict[str, dict]]] = None,
+        endpoint: Optional[Union[str, List[str], Dict[str, dict]]] = None,
     ):
         self._loop = asyncio.get_event_loop_policy().get_event_loop()
         self._agents = []

--- a/src/uagents/agent.py
+++ b/src/uagents/agent.py
@@ -54,7 +54,7 @@ class Agent(Sink):
         name: Optional[str] = None,
         port: Optional[int] = None,
         seed: Optional[str] = None,
-        endpoint: Optional[Union[List[str], Dict[str, dict]]] = None,
+        endpoint: Optional[Union[str, List[str], Dict[str, dict]]] = None,
         mailbox: Optional[Union[str, Dict[str, str]]] = None,
         resolve: Optional[Resolver] = None,
         version: Optional[str] = None,
@@ -339,6 +339,10 @@ class Agent(Sink):
         # register the internal agent protocol
         self.include(self._protocol)
         self._loop.run_until_complete(self._startup())
+        if self._endpoints is None:
+            self._logger.warning(
+                "I have no endpoint and won't be able to receive external messages"
+            )
         self.start_background_tasks()
 
     def start_background_tasks(self):
@@ -357,10 +361,6 @@ class Agent(Sink):
         if self._endpoints is not None:
             self._loop.create_task(
                 _run_interval(self._register, self._ctx, self._schedule_registration())
-            )
-        else:
-            self._logger.warning(
-                "I have no endpoint and won't be able to receive external messages"
             )
 
     def run(self):

--- a/src/uagents/config.py
+++ b/src/uagents/config.py
@@ -29,7 +29,7 @@ DEFAULT_ENVELOPE_TIMEOUT_SECONDS = 30
 
 
 def parse_endpoint_config(
-    endpoint: Optional[Union[List[str], Dict[str, dict]]]
+    endpoint: Optional[Union[str, List[str], Dict[str, dict]]]
 ) -> List[Dict[str, Any]]:
     if isinstance(endpoint, dict):
         endpoints = [
@@ -38,6 +38,8 @@ def parse_endpoint_config(
         ]
     elif isinstance(endpoint, list):
         endpoints = [{"url": val, "weight": 1} for val in endpoint]
+    elif isinstance(endpoint, str):
+        endpoints = [{"url": endpoint, "weight": 1}]
     else:
         endpoints = None
     return endpoints


### PR DESCRIPTION
When creating a bureau of agents that should be reachable externally and are not using the mailbox, users should set the endpoint of the bureau and need not set endpoints for the agents. Example:
```python
from uagents import Agent, Bureau

agent = Agent(name="agent")

port = 8000
bureau = Bureau(endpoint=f"http://127.0.0.1:{port}/submit", port=port)
bureau.add(agent)
bureau.run()
```