### PR TITLE
feat: add context.send_raw function

### DIFF
--- a/src/uagents/context.py
+++ b/src/uagents/context.py
@@ -12,7 +12,7 @@ from cosmpy.aerial.wallet import LocalWallet
 
 from uagents.config import DEFAULT_ENVELOPE_TIMEOUT_SECONDS
 from uagents.crypto import Identity
-from uagents.dispatch import dispatcher
+from uagents.dispatch import JsonStr, dispatcher
 from uagents.envelope import Envelope
 from uagents.models import Model, ErrorMessage
 from uagents.resolver import Resolver
@@ -103,10 +103,23 @@ class Context:
         message: Model,
         timeout: Optional[int] = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
     ):
-        # convert the message into object form
-        json_message = message.json()
         schema_digest = Model.build_schema_digest(message)
+        await self.send_raw(
+            destination,
+            message.json(),
+            schema_digest,
+            message_type=type(message),
+            timeout=timeout,
+        )
 
+    async def send_raw(
+        self,
+        destination: str,
+        json_message: JsonStr,
+        schema_digest: str,
+        message_type: Optional[Type[Model]] = None,
+        timeout: Optional[int] = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
+    ):
         # check if this message is a reply
         if (
             self._message_received is not None
@@ -118,7 +131,7 @@ class Context:
                 # ensure the reply is valid
                 if schema_digest not in self._replies[received.schema_digest]:
                     self._logger.exception(
-                        f"Outgoing message {type(message)} "
+                        f"Outgoing message {message_type or ''} "
                         f"is not a valid reply to {received.message}"
                     )
                     return
@@ -127,7 +140,7 @@ class Context:
         if self._message_received is None and self._interval_messages:
             if schema_digest not in self._interval_messages:
                 self._logger.exception(
-                    f"Outgoing message {type(message)} is not a valid interval message"
+                    f"Outgoing message {message_type} is not a valid interval message"
                 )
                 return
 
@@ -140,7 +153,7 @@ class Context:
 
         # handle queries waiting for a response
         if destination in self._queries:
-            self._queries[destination].set_result(message)
+            self._queries[destination].set_result((json_message, schema_digest))
             del self._queries[destination]
             return
 

--- a/src/uagents/query.py
+++ b/src/uagents/query.py
@@ -6,6 +6,7 @@ import aiohttp
 
 from uagents.config import get_logger
 from uagents.crypto import generate_user_address
+from uagents.dispatch import JsonStr
 from uagents.envelope import Envelope
 from uagents.models import Model
 from uagents.resolver import Resolver, AlmanacResolver
@@ -68,12 +69,19 @@ async def query(
 
 
 def enclose_response(message: Model, sender: str, session: str) -> str:
+    schema_digest = Model.build_schema_digest(message)
+    return enclose_response_raw(message.json(), schema_digest, sender, session)
+
+
+def enclose_response_raw(
+    json_message: JsonStr, schema_digest: str, sender: str, session: str
+) -> str:
     response_env = Envelope(
         version=1,
         sender=sender,
         target="",
         session=session,
-        schema_digest=Model.build_schema_digest(message),
+        schema_digest=schema_digest,
     )
-    response_env.encode_payload(message.json())
+    response_env.encode_payload(json_message)
     return response_env.json()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,7 +23,9 @@ class TestServer(unittest.IsolatedAsyncioTestCase):
     async def mock_process_sync_message(self, sender: str, msg: Model):
         while True:
             if sender in self.agent._server._queries:
-                self.agent._server._queries[sender].set_result(msg)
+                self.agent._server._queries[sender].set_result(
+                    (msg.json(), Model.build_schema_digest(msg))
+                )
                 return
 
     async def test_message_success(self):


### PR DESCRIPTION
Adds a `send_raw` function to send Json-encoded messages along with a schema digest for when the Pydantic Model is not available. This small refactor should be completely backwards compatible.