### PR TITLE
fix: add new session id to envelope if not already present in context

### DIFF
--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -149,7 +149,7 @@ class Context:
         self._resolver = resolve
         self._identity = identity
         self._queries = queries
-        self._session = session or uuid.uuid4()
+        self._session = session or None
         self._replies = replies
         self._interval_messages = interval_messages
         self._message_received = message_received
@@ -392,7 +392,7 @@ class Context:
             version=1,
             sender=self.address,
             target=destination_address,
-            session=self._session,
+            session=self._session or uuid.uuid4(),
             schema_digest=schema_digest,
             protocol_digest=self.get_message_protocol(schema_digest),
             expires=expires,


### PR DESCRIPTION
Session ID should only be created when sending an envelope either:
- supplied to the new context on receiving an incoming envelope
- or generated when no context is already present