### PR TITLE
feat: add default error handler

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -256,7 +256,7 @@ class Agent(Sink):
             )
 
         # define default error message handler
-        @self.on_message(ErrorMessage, allow_unverified=True)
+        @self.on_message(ErrorMessage)
         async def _handle_error_message(ctx: Context, sender: str, msg: ErrorMessage):
             ctx.logger.warning(f"Received error message from {sender}: {msg.error}")
 

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -258,7 +258,7 @@ class Agent(Sink):
         # define default error message handler
         @self.on_message(ErrorMessage)
         async def _handle_error_message(ctx: Context, sender: str, msg: ErrorMessage):
-            ctx.logger.warning(f"Received error message from {sender}: {msg.error}")
+            ctx.logger.exception(f"Received error message from {sender}: {msg.error}")
 
     def _initialize_wallet_and_identity(self, seed, name):
         """

--- a/python/tests/test_agent.py
+++ b/python/tests/test_agent.py
@@ -50,7 +50,7 @@ class TestAgent(unittest.TestCase):
         signed_msg_handlers = self.agent._protocol._signed_message_handlers
         unsigned_msg_handlers = self.agent._protocol._unsigned_message_handlers
 
-        self.assertEqual(len(unsigned_msg_handlers), 0)
+        self.assertEqual(len(unsigned_msg_handlers), 1)
         self.assertEqual(len(signed_msg_handlers), 1)
         self.assertTrue(isinstance(signed_msg_handlers[MESSAGE_DIGEST], Callable))
 
@@ -62,7 +62,7 @@ class TestAgent(unittest.TestCase):
         signed_msg_handlers = self.agent._protocol._signed_message_handlers
         unsigned_msg_handlers = self.agent._protocol._unsigned_message_handlers
 
-        self.assertEqual(len(unsigned_msg_handlers), 1)
+        self.assertEqual(len(unsigned_msg_handlers), 2)
         self.assertEqual(len(signed_msg_handlers), 1)
         self.assertTrue(isinstance(signed_msg_handlers[MESSAGE_DIGEST], Callable))
         self.assertTrue(isinstance(unsigned_msg_handlers[QUERY_DIGEST], Callable))

--- a/python/tests/test_agent.py
+++ b/python/tests/test_agent.py
@@ -50,8 +50,8 @@ class TestAgent(unittest.TestCase):
         signed_msg_handlers = self.agent._protocol._signed_message_handlers
         unsigned_msg_handlers = self.agent._protocol._unsigned_message_handlers
 
-        self.assertEqual(len(unsigned_msg_handlers), 1)
-        self.assertEqual(len(signed_msg_handlers), 1)
+        self.assertEqual(len(unsigned_msg_handlers), 0)
+        self.assertEqual(len(signed_msg_handlers), 2)
         self.assertTrue(isinstance(signed_msg_handlers[MESSAGE_DIGEST], Callable))
 
     def test_agent_on_unsigned_message(self):
@@ -62,8 +62,8 @@ class TestAgent(unittest.TestCase):
         signed_msg_handlers = self.agent._protocol._signed_message_handlers
         unsigned_msg_handlers = self.agent._protocol._unsigned_message_handlers
 
-        self.assertEqual(len(unsigned_msg_handlers), 2)
-        self.assertEqual(len(signed_msg_handlers), 1)
+        self.assertEqual(len(unsigned_msg_handlers), 1)
+        self.assertEqual(len(signed_msg_handlers), 2)
         self.assertTrue(isinstance(signed_msg_handlers[MESSAGE_DIGEST], Callable))
         self.assertTrue(isinstance(unsigned_msg_handlers[QUERY_DIGEST], Callable))
 


### PR DESCRIPTION
- Renames misnamed `_handle_error` function to `_send_error_message`
- Adds a default error handler that can easily be overwritten if desired

A possible bonus is that rather than an empty protocol being default, the default protocol will now have something in it.