### PR TITLE
docs: fixed broken examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Please see the [official documentation](https://docs.fetch.ai/) for full setup i
 
 ## 🌱 Examples
 
-The [`examples`](https://github.com/fetchai/uAgents/tree/main/examples) folder contains several examples of how to create and run various types of agents.
+The [`examples`](https://github.com/fetchai/uAgents/tree/main/python/examples) folder contains several examples of how to create and run various types of agents.
 
 ## Python Library
 


### PR DESCRIPTION
The main branch's examples link did not include the parent '/python' folder. I have replaced it with the correct '../python/examples' URL.