### PR TITLE
chore: import wallet message and bump version for patch release

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uagents"
-version = "0.9.0"
+version = "0.9.1"
 description = "Lightweight framework for rapid agent-based development"
 authors = ["Ed FitzGerald <edward.fitzgerald@fetch.ai>", "James Riehl <james.riehl@fetch.ai>", "Alejandro Morales <alejandro.madrigal@fetch.ai>"]
 license = "Apache 2.0"

--- a/python/src/uagents/wallet_messaging.py
+++ b/python/src/uagents/wallet_messaging.py
@@ -4,7 +4,11 @@ import functools
 import logging
 from typing import List, Optional
 
-from babble import Client, Identity as BabbleIdentity
+from babble import (  # pylint: disable=unused-import
+    Client,
+    Identity as BabbleIdentity,
+    Message as WalletMessage,
+)
 from cosmpy.aerial.wallet import LocalWallet
 from requests import HTTPError, JSONDecodeError
 


### PR DESCRIPTION
This reverts an incorrect deletion of an import that appears to be unused but is actually important for agents that use the wallet messaging feature.