### PR TITLE
fix: catch all wallet messaging exceptions

### DIFF
--- a/python/src/uagents/wallet_messaging.py
+++ b/python/src/uagents/wallet_messaging.py
@@ -60,7 +60,10 @@ class WalletMessagingClient:
         return decorator_on_message
 
     async def send(self, destination: str, msg: str, msg_type: int = 1):
-        self._client.send(destination, msg, msg_type)
+        try:
+            self._client.send(destination, msg, msg_type)
+        except Exception as ex:
+            self._logger.warning(f"Failed to send message to {destination}: {ex}")
 
     async def poll_server(self):
         self._logger.info("Connecting to wallet messaging server")
@@ -72,6 +75,7 @@ class WalletMessagingClient:
                 HTTPError,
                 ConnectionError,
                 JSONDecodeError,
+                Exception,
             ) as ex:
                 self._logger.warning(
                     f"Failed to get messages from wallet messaging server: {ex}"

--- a/python/src/uagents/wallet_messaging.py
+++ b/python/src/uagents/wallet_messaging.py
@@ -63,7 +63,7 @@ class WalletMessagingClient:
         try:
             self._client.send(destination, msg, msg_type)
         except Exception as ex:
-            self._logger.warning(f"Failed to send message to {destination}: {ex}")
+            self._logger.exception(f"Failed to send message to {destination}: {ex}")
 
     async def poll_server(self):
         self._logger.info("Connecting to wallet messaging server")


### PR DESCRIPTION
Not all exceptions were being caught, leading to silent failure of the wallet messaging client.