### PR TITLE
feat: updates to match aname contract-V2

### DIFF
--- a/python/examples/13-agent-name-service/agent1.py
+++ b/python/examples/13-agent-name-service/agent1.py
@@ -22,7 +22,7 @@ bob = Agent(
 my_wallet = LocalWallet.from_unsafe_seed("registration test wallet")
 name_service_contract = get_name_service_contract(test=True)
 faucet = get_faucet()
-DOMAIN = "agent"
+DOMAIN = "example.agent"
 
 faucet.get_wealth(my_wallet.address())
 

--- a/python/examples/13-agent-name-service/agent2.py
+++ b/python/examples/13-agent-name-service/agent2.py
@@ -14,6 +14,7 @@ alice = Agent(
 
 DOMAIN = "example.agent"
 
+
 @alice.on_interval(period=5)
 async def alice_interval_handler(ctx: Context):
     bob_name = "bob-0" + "." + DOMAIN

--- a/python/examples/13-agent-name-service/agent2.py
+++ b/python/examples/13-agent-name-service/agent2.py
@@ -12,10 +12,11 @@ alice = Agent(
     endpoint=["http://localhost:8000/submit"],
 )
 
+DOMAIN = "example.agent"
 
 @alice.on_interval(period=5)
 async def alice_interval_handler(ctx: Context):
-    bob_name = "bob-0.agent"
+    bob_name = "bob-0" + "." + DOMAIN
     ctx.logger.info(f"Sending message to {bob_name}...")
     await ctx.send(bob_name, Message(message="Hello there bob."))
 

--- a/python/src/uagents/config.py
+++ b/python/src/uagents/config.py
@@ -25,7 +25,7 @@ MAINNET_CONTRACT_NAME_SERVICE = (
     "fetch1479lwv5vy8skute5cycuz727e55spkhxut0valrcm38x9caa2x8q99ef0q"
 )
 TESTNET_CONTRACT_NAME_SERVICE = (
-    "fetch1mxz8kn3l5ksaftx8a9pj9a6prpzk2uhxnqdkwuqvuh37tw80xu6qges77l"
+    "fetch1kewgfwxwtuxcnppr547wj6sd0e5fkckyp48dazsh89hll59epgpspmh0tn"
 )
 REGISTRATION_FEE = 500000000000000000
 REGISTRATION_DENOM = "atestfet"

--- a/python/src/uagents/config.py
+++ b/python/src/uagents/config.py
@@ -25,7 +25,7 @@ MAINNET_CONTRACT_NAME_SERVICE = (
     "fetch1479lwv5vy8skute5cycuz727e55spkhxut0valrcm38x9caa2x8q99ef0q"
 )
 TESTNET_CONTRACT_NAME_SERVICE = (
-    "fetch1kewgfwxwtuxcnppr547wj6sd0e5fkckyp48dazsh89hll59epgpspmh0tn"
+    "fetch1mxz8kn3l5ksaftx8a9pj9a6prpzk2uhxnqdkwuqvuh37tw80xu6qges77l"
 )
 REGISTRATION_FEE = 500000000000000000
 REGISTRATION_DENOM = "atestfet"

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -345,8 +345,10 @@ class NameServiceContract(LedgerContract):
         Returns:
             bool: True if the domain is public, False otherwise.
         """
-        res = self.query({"domain_record": {"domain": f"VAL.{domain}"}})
-        return res["is_public"]
+        res = self.query({"query_domain_flags": {"domain": domain}}).get("domain_flags")
+        if res:
+            return res["web3_flags"]["is_public"]
+        return False
 
     def get_registration_tx(
         self,

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -483,7 +483,8 @@ class NameServiceContract(LedgerContract):
             ):
                 logger.warning(
                     "Address %s needs to be registered in almanac contract "
-                    "to be registered in a domain", agent_address
+                    "to be registered in a domain",
+                    agent_address,
                 )
                 return
 

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -482,8 +482,8 @@ class NameServiceContract(LedgerContract):
                 agent_address
             ):
                 logger.warning(
-                    f"Address {agent_address} needs to be registered in almanac contract "
-                    + "to be registered in a domain"
+                    "Address %s needs to be registered in almanac contract "
+                    "to be registered in a domain", agent_address
                 )
                 return
 

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -345,7 +345,7 @@ class NameServiceContract(LedgerContract):
         Returns:
             bool: True if the domain is public, False otherwise.
         """
-        res = self.query({"query_domain_flags": {"domain": domain}}).get("domain_flags")
+        res = self.query({"query_domain_flags": {"domain": domain.split(".")[-1]}}).get("domain_flags")
         if res:
             return res["web3_flags"]["is_public"]
         return False

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -345,7 +345,9 @@ class NameServiceContract(LedgerContract):
         Returns:
             bool: True if the domain is public, False otherwise.
         """
-        res = self.query({"query_domain_flags": {"domain": domain.split(".")[-1]}}).get("domain_flags")
+        res = self.query({"query_domain_flags": {"domain": domain.split(".")[-1]}}).get(
+            "domain_flags"
+        )
         if res:
             return res["web3_flags"]["is_public"]
         return False

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -483,7 +483,7 @@ class NameServiceContract(LedgerContract):
             ):
                 logger.warning(
                     f"Address {agent_address} needs to be registered in almanac contract "
-                    f"to be registered in a domain"
+                    + "to be registered in a domain"
                 )
                 return
 

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -467,8 +467,9 @@ class NameServiceContract(LedgerContract):
             agent_address (str): The address of the agent.
             name (str): The name to be registered.
             domain (str): The domain in which the name is registered.
-            overwrite (bool, optional): Whether to overwrite the existing name.
-            Defaults to True.
+            overwrite (bool, optional): Specifies whether to overwrite any existing
+                addresses registered to the domain. If False, the address will be
+                appended to the previous records. Defaults to True.
         """
         logger.info("Registering name...")
         chain_id = ledger.query_chain_id()

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -460,7 +460,8 @@ class NameServiceContract(LedgerContract):
                 agent_address
             ):
                 logger.warning(
-                    f"Address {agent_address} needs to be registered in almanac contract to be registered in a domain"
+                    f"Address {agent_address} needs to be registered in almanac contract "
+                    f"to be registered in a domain"
                 )
                 return
 

--- a/python/src/uagents/resolver.py
+++ b/python/src/uagents/resolver.py
@@ -137,7 +137,6 @@ def get_agent_address(name: str, test: bool) -> str:
             selected_address = (
                 selected_address_list[0] if selected_address_list else None
             )
-            print(selected_address)
             return selected_address
     return None
 

--- a/python/src/uagents/resolver.py
+++ b/python/src/uagents/resolver.py
@@ -130,13 +130,11 @@ def get_agent_address(name: str, test: bool) -> str:
     result = get_name_service_contract(test).query(query_msg)
     if result["record"] is not None:
         registered_records = result["record"]["records"][0]["agent_address"]["records"]
-        print(registered_records)
         if len(registered_records) > 0:
             addresses = [val.get("address") for val in registered_records]
             weights = [val.get("weight") for val in registered_records]
             selected_address_list = weighted_random_sample(addresses, weights=weights)
             selected_address = selected_address_list[0] if selected_address_list else None
-            print("SELECTED:")
             print(selected_address)
             return selected_address
     return None

--- a/python/src/uagents/resolver.py
+++ b/python/src/uagents/resolver.py
@@ -129,9 +129,16 @@ def get_agent_address(name: str, test: bool) -> str:
     query_msg = {"domain_record": {"domain": f"{name}"}}
     result = get_name_service_contract(test).query(query_msg)
     if result["record"] is not None:
-        registered_address = result["record"]["records"][0]["agent_address"]["records"]
-        if len(registered_address) > 0:
-            return registered_address[0]["address"]
+        registered_records = result["record"]["records"][0]["agent_address"]["records"]
+        print(registered_records)
+        if len(registered_records) > 0:
+            addresses = [val.get("address") for val in registered_records]
+            weights = [val.get("weight") for val in registered_records]
+            selected_address_list = weighted_random_sample(addresses, weights=weights)
+            selected_address = selected_address_list[0] if selected_address_list else None
+            print("SELECTED:")
+            print(selected_address)
+            return selected_address
     return None
 
 

--- a/python/src/uagents/resolver.py
+++ b/python/src/uagents/resolver.py
@@ -134,7 +134,9 @@ def get_agent_address(name: str, test: bool) -> str:
             addresses = [val.get("address") for val in registered_records]
             weights = [val.get("weight") for val in registered_records]
             selected_address_list = weighted_random_sample(addresses, weights=weights)
-            selected_address = selected_address_list[0] if selected_address_list else None
+            selected_address = (
+                selected_address_list[0] if selected_address_list else None
+            )
             print(selected_address)
             return selected_address
     return None


### PR DESCRIPTION
This PR performs the needed updates to match `ANAME v2.0` contract with uAgents.
Now funds are required to register a domain, by default we set the registration time= 24 hours.
There are 2 main scenarios when attempting to register a domain:

- If the domain is available it will be registered and update the record with the agent address
- If the domain is not available (already registered and active) but the current wallet is the owner of the domain it will only update the record with the agent address
- If the domain is not available and the current wallet is not the owner of the domain, no registration will be attempted since another wallet owns the domain

For the name registration example (examples/13-agent-name-service) domain `example.agent` has been registered for around 3 months for "registration test wallet". So subdomains like `bob.example.agent` can be registered.
