### PR TITLE
feat(core): add capability to define default behaviour to dialogue edges

### DIFF
--- a/python/examples/17-stateful-communication/agent1.py
+++ b/python/examples/17-stateful-communication/agent1.py
@@ -2,8 +2,15 @@
 
 import json
 
-from dialogues.chitchat import ChitChatDialogue
-from uagents import Agent, Context, Model
+from dialogues.chitchat import (
+    AcceptChitChatDialogue,
+    ChitChatDialogue,
+    ChitChatDialogueMessage,
+    ConcludeChitChatDialogue,
+    InitiateChitChatDialogue,
+    RejectChitChatDialogue,
+)
+from uagents import Agent, Context
 
 CHAT_AGENT_ADDRESS = "agent1qgp7urkvx24a2gs8e7496fajzy78h4887vz7va4h7klzf7azzhthsz7zymu"
 
@@ -14,27 +21,6 @@ agent = Agent(
     endpoint="http://127.0.0.1:8001/submit",
     log_level="DEBUG",
 )
-
-
-# define dialogue messages; each transition needs a separate message
-class InitiateChitChatDialogue(Model):
-    pass
-
-
-class AcceptChitChatDialogue(Model):
-    pass
-
-
-class ChitChatDialogueMessage(Model):
-    text: str
-
-
-class ConcludeChitChatDialogue(Model):
-    pass
-
-
-class RejectChitChatDialogue(Model):
-    pass
 
 
 # instantiate the dialogues
@@ -49,6 +35,7 @@ print(json.dumps(chitchat_dialogue.get_overview(), indent=4))
 print("---")
 
 
+# overwrite default behaviour and accept the dialogue
 @chitchat_dialogue.on_initiate_session(InitiateChitChatDialogue)
 async def start_chitchat(
     ctx: Context,

--- a/python/examples/17-stateful-communication/agent2.py
+++ b/python/examples/17-stateful-communication/agent2.py
@@ -2,8 +2,15 @@
 
 from asyncio import sleep
 
-from dialogues.chitchat import ChitChatDialogue
-from uagents import Agent, Context, Model
+from dialogues.chitchat import (
+    AcceptChitChatDialogue,
+    ChitChatDialogue,
+    ChitChatDialogueMessage,
+    ConcludeChitChatDialogue,
+    InitiateChitChatDialogue,
+    RejectChitChatDialogue,
+)
+from uagents import Agent, Context
 
 CHIT_AGENT_ADDRESS = "agent1qvhlqy2a4lk9gge8ug7l65a6k07wc92hh2d5jhwtat0zakrtg08njmfn00j"
 
@@ -16,43 +23,11 @@ agent = Agent(
 )
 
 
-# define dialogue messages; each transition needs a separate message
-class InitiateChitChatDialogue(Model):
-    pass
-
-
-class AcceptChitChatDialogue(Model):
-    pass
-
-
-class ChitChatDialogueMessage(Model):
-    text: str
-
-
-class ConcludeChitChatDialogue(Model):
-    pass
-
-
-class RejectChitChatDialogue(Model):
-    pass
-
-
 # instantiate the dialogues
 chitchat_dialogue = ChitChatDialogue(
     version="0.1",
     agent_address=agent.address,
 )
-
-
-@chitchat_dialogue.on_initiate_session(InitiateChitChatDialogue)
-async def start_chitchat(
-    ctx: Context,
-    sender: str,
-    _msg: InitiateChitChatDialogue,
-):
-    ctx.logger.info(f"Received init message from {sender}")
-    # do something when the dialogue is initiated
-    await ctx.send(sender, AcceptChitChatDialogue())
 
 
 @chitchat_dialogue.on_start_dialogue(AcceptChitChatDialogue)

--- a/python/examples/17-stateful-communication/dialogues/chitchat.py
+++ b/python/examples/17-stateful-communication/dialogues/chitchat.py
@@ -1,9 +1,38 @@
-"""Specific dialogue class for the chit-chat dialogue."""
+"""
+Specific dialogue class for the chit-chat dialogue.
+
+The contents of this file are to be shared between the agents that want to
+use this dialogue. This defines the structure of the specific dialogue and
+the messages that are expected to be exchanged.
+"""
 
 from typing import Type
 
 from uagents import Model
+from uagents.context import Context
 from uagents.experimental.dialogues import Dialogue, Edge, Node
+
+
+# define dialogue messages; each transition needs a separate message
+class InitiateChitChatDialogue(Model):
+    pass
+
+
+class AcceptChitChatDialogue(Model):
+    pass
+
+
+class ChitChatDialogueMessage(Model):
+    text: str
+
+
+class ConcludeChitChatDialogue(Model):
+    pass
+
+
+class RejectChitChatDialogue(Model):
+    pass
+
 
 # Node definition for the dialogue states
 default_state = Node(
@@ -64,6 +93,20 @@ end_session = Edge(
     parent=chatting_state,
     child=end_state,
 )
+
+
+# define default behaviour for individual dialogue edges
+async def reject_dialogue(
+    ctx: Context,
+    sender: str,
+    _msg: InitiateChitChatDialogue,
+):
+    """This function is the default behaviour of this specific step in the diaglogue."""
+    ctx.logger.debug("Automatically reject Dialogue request.")
+    await ctx.send(sender, RejectChitChatDialogue())
+
+
+init_session.set_default_behaviour(InitiateChitChatDialogue, reject_dialogue)
 
 
 class ChitChatDialogue(Dialogue):

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -761,10 +761,11 @@ class Agent(Sink):
         self._interval_messages.update(protocol.interval_messages)
 
         for schema_digest in protocol.models:
-            if schema_digest in self._models:
-                raise RuntimeError("Unable to register duplicate model")
-            if schema_digest in self._signed_message_handlers:
-                raise RuntimeError("Unable to register duplicate message handler")
+            if not hasattr(protocol, "rules"):
+                if schema_digest in self._models:
+                    raise RuntimeError("Unable to register duplicate model")
+                if schema_digest in self._signed_message_handlers:
+                    raise RuntimeError("Unable to register duplicate message handler")
             if schema_digest in protocol.signed_message_handlers:
                 self._signed_message_handlers[schema_digest] = (
                     protocol.signed_message_handlers[schema_digest]

--- a/python/src/uagents/experimental/dialogues/__init__.py
+++ b/python/src/uagents/experimental/dialogues/__init__.py
@@ -40,15 +40,13 @@ class Edge:
         description: str,
         parent: Optional[Node],  # tail
         child: Node,  # head
-        model: Optional[Type[Model]] = None,
-        func: MessageCallback = lambda *args, **kwargs: None,
     ) -> None:
         self.name = name
         self.description = description
         self.parent = parent
         self.child = child
-        self._model = model
-        self._func = func
+        self._model = None
+        self._func = None
 
     @property
     def model(self) -> Optional[Type[Model]]:
@@ -57,6 +55,7 @@ class Edge:
 
     @model.setter
     def model(self, model: Type[Model]) -> None:
+        """Set the message model type for the edge."""
         self._model = model
 
     @property
@@ -64,8 +63,9 @@ class Edge:
         """The message handler that is associated with the edge."""
         return self._func
 
-    @func.setter
-    def func(self, func: MessageCallback) -> None:
+    def set_default_behaviour(self, model: Type[Model], func: MessageCallback):
+        """Set the default behaviour for the edge."""
+        self._model = model
         self._func = func
 
 
@@ -300,7 +300,7 @@ class Dialogue(Protocol):
     def _auto_add_message_handler(self) -> None:
         """Automatically add message handlers for edges with models."""
         for edge in self._edges:
-            if edge.model:
+            if edge.model and edge.func:
                 model_digest = Model.build_schema_digest(edge.model)
                 self._models[model_digest] = edge.model
                 self._signed_message_handlers[model_digest] = edge.func


### PR DESCRIPTION
Adding the capability to define default behaviour to dialogue edges.

The example is modified so that when including the ChitChatDialogue all attempts of initiating a dialogue will be rejected by default and will only be allowed if you specifically write a handler that does so.

> This is just a minor example to demonstrate how we can effectively build complex dialogues that automate certain steps without the user having to modify/copy every individual step (which is part of the main benefits of dialogues from their inception)