### PR TITLE
feat(core): add broadcast functionality to dialogues

### DIFF
--- a/python/examples/14-broadcast/main.py
+++ b/python/examples/14-broadcast/main.py
@@ -37,7 +37,8 @@ bob.include(proto)
 # let charles send the message to all agents supporting the protocol
 @charles.on_interval(period=5)
 async def say_hello(ctx: Context):
-    await ctx.broadcast(proto.digest, message=BroadcastExampleRequest())
+    status_list = await ctx.broadcast(proto.digest, message=BroadcastExampleRequest())
+    ctx.logger.info(f"Trying to contact {len(status_list)} agents.")
 
 
 @charles.on_message(model=BroadcastExampleResponse)

--- a/python/src/uagents/communication.py
+++ b/python/src/uagents/communication.py
@@ -59,6 +59,7 @@ class MsgStatus:
     detail: str
     destination: str
     endpoint: str
+    session: Optional[uuid.UUID] = None
 
 
 class Dispenser:
@@ -125,6 +126,7 @@ async def dispatch_local_message(
         detail="Message dispatched locally",
         destination=destination,
         endpoint="",
+        session=session_id,
     )
 
 
@@ -166,6 +168,7 @@ async def send_exchange_envelope(
                             detail="Message successfully delivered via HTTP",
                             destination=envelope.target,
                             endpoint=endpoint,
+                            session=envelope.session,
                         )
                 LOGGER.warning(
                     f"Failed to send message to {envelope.target} @ {endpoint}: "
@@ -187,6 +190,7 @@ async def send_exchange_envelope(
         detail="Message delivery failed",
         destination=envelope.target,
         endpoint="",
+        session=envelope.session,
     )
 
 
@@ -204,6 +208,7 @@ async def dispatch_sync_response_envelope(env: Envelope) -> MsgStatus:
         detail="Sync message successfully delivered via HTTP",
         destination=env.target,
         endpoint="",
+        session=env.session,
     )
 
 
@@ -245,6 +250,7 @@ async def send_sync_message(
             detail="Failed to resolve destination address",
             destination=destination,
             endpoint="",
+            session=None,
         )
 
     env = Envelope(

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -355,7 +355,8 @@ class InternalContext(Context):
             )
             return []
 
-        agents.remove(self.agent.address)
+        if self.agent.address in agents:
+            agents.remove(self.agent.address)
         futures = await asyncio.gather(
             *[
                 self.send(

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -408,6 +408,7 @@ class InternalContext(Context):
                 detail="Invalid interval message",
                 destination=destination,
                 endpoint="",
+                session=self._session,
             )
 
         return await self.send_raw(
@@ -455,6 +456,7 @@ class InternalContext(Context):
                     detail="Sync message resolved",
                     destination=parsed_address,
                     endpoint="",
+                    session=self._session,
                 )
 
             self._outbound_messages[parsed_address] = (
@@ -474,6 +476,7 @@ class InternalContext(Context):
                 detail="Unable to resolve destination endpoint",
                 destination=destination,
                 endpoint="",
+                session=self._session,
             )
 
         # Calculate when the envelope expires
@@ -506,6 +509,7 @@ class InternalContext(Context):
                 detail="Timeout waiting for response",
                 destination=destination,
                 endpoint="",
+                session=self._session,
             )
 
         if isinstance(result, Envelope):
@@ -648,6 +652,7 @@ class ExternalContext(InternalContext):
                 detail="Invalid reply",
                 destination=destination,
                 endpoint="",
+                session=self._session,
             )
 
         return await self.send_raw(

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -333,7 +333,7 @@ class InternalContext(Context):
         )
         if response.status_code == 200:
             data = response.json()
-            agents = [agent["address"] for agent in data if agent["status"] == "local"]
+            agents = [agent["address"] for agent in data if agent["status"] == "active"]
             return agents[:limit]
         return []
 

--- a/python/src/uagents/experimental/dialogues/__init__.py
+++ b/python/src/uagents/experimental/dialogues/__init__.py
@@ -353,7 +353,7 @@ class Dialogue(Protocol):
         return is_valid
 
     def _post_handle_hook(self, ctx: Context, sender: str, msg_in: Type[Model]) -> bool:
-        if self.is_finished(ctx.session):
+        if self.is_finished(ctx.session) or not ctx.outbound_messages:
             return True
         inbound_schema_digest = Model.build_schema_digest(msg_in)
         outbound_message_content, outbound_schema_digest = ctx.outbound_messages[sender]
@@ -395,6 +395,7 @@ class Dialogue(Protocol):
                     detail="Invalid dialogue reply",
                     destination=sender,
                     endpoint="",
+                    session=ctx.session,
                 )
 
             return result
@@ -608,7 +609,7 @@ class Dialogue(Protocol):
 
     async def start_dialogue(
         self, ctx: Context, destination: str, message: Model
-    ) -> MsgStatus:
+    ) -> List[MsgStatus]:
         """
         Start a dialogue with a message.
 
@@ -626,19 +627,30 @@ class Dialogue(Protocol):
                 "A dialogue can only be started with the specified starting message"
             )
 
-        msg_status = await ctx.send(destination, message)
+        status_list: List[MsgStatus] = []
 
-        self.add_message(
-            session_id=ctx.session,
-            message_type=self.models[message_schema_digest].__name__,
-            schema_digest=message_schema_digest,
-            sender=ctx.agent.address,
-            receiver=destination,
-            content=message.json(),
-        )
-        self.update_state(message_schema_digest, ctx.session)
+        if destination.startswith("proto:"):
+            status_list = await ctx.broadcast(destination, message)
+        elif destination.startswith("agent"):
+            status_list.append(await ctx.send(destination, message))
+        else:
+            raise ValueError("Invalid destination address")
 
-        return msg_status
+        for status in status_list:
+            if status.status == DeliveryStatus.FAILED:
+                continue
+
+            self.add_message(
+                session_id=status.session,
+                message_type=self.models[message_schema_digest].__name__,
+                schema_digest=message_schema_digest,
+                sender=ctx.agent.address,
+                receiver=status.destination,
+                content=message.json(),
+            )
+            self.update_state(message_schema_digest, status.session)
+
+        return status_list
 
     def initialise_cleanup_task(self, interval: int = 1) -> None:
         """

--- a/python/src/uagents/experimental/dialogues/__init__.py
+++ b/python/src/uagents/experimental/dialogues/__init__.py
@@ -615,7 +615,7 @@ class Dialogue(Protocol):
 
         Args:
             ctx (Context): The current message context
-            destination (str): Agent address of the receiver
+            destination (str): Either the agent address of the receiver or a protocol digest
             message (Model): The current message to send
 
         Raises:

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -77,6 +77,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message dispatched locally",
             destination=bob.address,
             endpoint="",
+            session=self.context.session,
         )
 
         self.assertEqual(result, exp_msg_status)
@@ -91,6 +92,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message dispatched locally",
             destination=bob.address,
             endpoint="",
+            session=context.session,
         )
 
         self.assertEqual(result, exp_msg_status)
@@ -105,6 +107,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Invalid reply",
             destination=bob.address,
             endpoint="",
+            session=context.session,
         )
 
         self.assertEqual(result, exp_msg_status)
@@ -117,6 +120,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message dispatched locally",
             destination=bob.address,
             endpoint="",
+            session=self.context.session,
         )
 
         self.assertEqual(result, exp_msg_status)
@@ -130,6 +134,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Invalid interval message",
             destination=bob.address,
             endpoint="",
+            session=self.context.session,
         )
 
         self.assertEqual(result, exp_msg_status)
@@ -148,6 +153,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Sync message resolved",
             destination=clyde.address,
             endpoint="",
+            session=context.session,
         )
 
         self.assertEqual(future.result(), (msg.json(), msg_digest))
@@ -162,6 +168,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Unable to resolve destination endpoint",
             destination=destination,
             endpoint="",
+            session=self.context.session,
         )
 
         self.assertEqual(result, exp_msg_status)
@@ -180,6 +187,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message successfully delivered via HTTP",
             destination=clyde.address,
             endpoint=endpoints[0],
+            session=self.context.session,
         )
 
         # Assertions
@@ -199,6 +207,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message delivery failed",
             destination=clyde.address,
             endpoint="",
+            session=self.context.session,
         )
 
         # Assertions
@@ -223,6 +232,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message successfully delivered via HTTP",
             destination=clyde.address,
             endpoint=endpoints[0],
+            session=self.context.session,
         )
 
         # Assertions
@@ -252,6 +262,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message successfully delivered via HTTP",
             destination=clyde.address,
             endpoint=endpoints[1],
+            session=self.context.session,
         )
 
         # Assertions
@@ -278,6 +289,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             detail="Message delivery failed",
             destination=clyde.address,
             endpoint="",
+            session=self.context.session,
         )
 
         # Assertions


### PR DESCRIPTION
Also the following:
- add optional session id to MsgStatus
- fix broadcast method due to changed API
- refactor error messages in send_exchange_envelope method


It is now possible to use a protocol digest for the destination argument in `Dialogue.start_dialogue(...)` to start a dialogue with multiple agents at the same time.