### PR TITLE
fix(core): return envelope if no sinks in dispatcher

### DIFF
--- a/python/src/uagents/communication.py
+++ b/python/src/uagents/communication.py
@@ -191,8 +191,11 @@ async def send_exchange_envelope(
     )
 
 
-async def dispatch_sync_response_envelope(env: Envelope) -> MsgStatus:
+async def dispatch_sync_response_envelope(env: Envelope) -> Union[MsgStatus, Envelope]:
     """Dispatch a synchronous response envelope locally."""
+    # If there are no sinks registered, return the envelope back to the caller
+    if len(dispatcher.sinks) == 0:
+        return env
     await dispatcher.dispatch(
         env.sender,
         env.target,

--- a/python/src/uagents/dispatch.py
+++ b/python/src/uagents/dispatch.py
@@ -25,6 +25,10 @@ class Dispatcher:
     def __init__(self):
         self._sinks: Dict[str, Set[Sink]] = {}
 
+    @property
+    def sinks(self) -> Dict[str, Set[Sink]]:
+        return self._sinks
+
     def register(self, address: str, sink: Sink):
         destinations = self._sinks.get(address, set())
         destinations.add(sink)


### PR DESCRIPTION
## Proposed Changes

Restores the functionality of getting a return envelope when sending a sync message from a standalone function, as in https://github.com/fetchai/uAgents/blob/main/python/examples/08-local-network-interaction/sync_sender.py.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
