### PR TITLE
chore(core): bump version to 0.13.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uagents"
-version = "0.13.0"
+version = "0.13.1"
 description = "Lightweight framework for rapid agent-based development"
 authors = [
     "Ed FitzGerald <edward.fitzgerald@fetch.ai>",


### PR DESCRIPTION
## Description

Bump version to 0.13.1 to support the most recent fetchai-babble package.
