### PR TITLE
feat(core): add bureau shutdown event support

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -1191,4 +1191,8 @@ class Bureau:
         if not self._use_mailbox:
             tasks.append(self._loop.create_task(self._server.serve()))
 
-        self._loop.run_until_complete(asyncio.gather(*tasks))
+        try:
+            self._loop.run_until_complete(asyncio.gather(*tasks))
+        finally:
+            for agent in self._agents:
+                self._loop.run_until_complete(agent._shutdown())


### PR DESCRIPTION
## Proposed Changes

Add support for shutdown tasks within the agent Bureau

## Linked Issues

Closes #90 

## Types of changes

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation

## Further comments

To verify please execute the following snippet:
```python
from uagents import Agent, Bureau, Context

alice = Agent(name="Alice", seed="<seed>")
bob = Agent(name="Bob", seed="<seed>")

bureau = Bureau(
    agents=[alice, bob],
    port=8080,
    endpoint="http://localhost:8080/submit",
)

@alice.on_event("startup")
async def startup1(ctx: Context):
    ctx.logger.info(">>> Alice is starting up.")

@bob.on_event("startup")
async def startup2(ctx: Context):
    ctx.logger.info(">>> Bob is starting up.")

@alice.on_event("shutdown")
async def shutdown1(ctx: Context):
    ctx.logger.info(">>> Alice is shutting down.")

@bob.on_event("shutdown")
async def shutdown2(ctx: Context):
    ctx.logger.info(">>> Bob is shutting down.")

bureau.run()
```