### PR TITLE
feat(core): separate asyncio tasks and running

### DIFF
--- a/python/examples/18-async-loops/external_loop_attach.py
+++ b/python/examples/18-async-loops/external_loop_attach.py
@@ -1,0 +1,46 @@
+import asyncio
+import contextlib
+
+from uagents import Agent, Bureau, Context
+
+loop = asyncio.get_event_loop()
+
+
+agent = Agent(
+    name="looper",
+    seed="<YOUR_SEED>",
+)
+
+bureau = Bureau(
+    agents=[agent],
+)
+
+
+@agent.on_event("startup")
+async def startup(ctx: Context):
+    ctx.logger.info(">>> Looper is starting up.")
+
+
+@agent.on_event("shutdown")
+async def shutdown(ctx: Context):
+    ctx.logger.info(">>> Looper is shutting down.")
+
+
+async def coro():
+    while True:
+        print("doing hard work...")
+        await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    print("Attaching the agent or bureau to the external loop...")
+    loop.create_task(coro())
+
+    # > when attaching the agent to the external loop
+    loop.create_task(agent.run_async())
+
+    # > when attaching a bureau to the external loop
+    # loop.create_task(bureau.run_async())
+
+    with contextlib.suppress(KeyboardInterrupt):
+        loop.run_forever()

--- a/python/examples/18-async-loops/external_loop_run.py
+++ b/python/examples/18-async-loops/external_loop_run.py
@@ -1,0 +1,44 @@
+import asyncio
+
+from uagents import Agent, Bureau, Context
+
+loop = asyncio.get_event_loop()
+
+
+agent = Agent(
+    name="looper",
+    seed="<YOUR_SEED>",
+    loop=loop,
+)
+
+bureau = Bureau(
+    agents=[agent],
+    loop=loop,
+)
+
+
+@agent.on_event("startup")
+async def startup(ctx: Context):
+    ctx.logger.info(">>> Looper is starting up.")
+
+
+@agent.on_event("shutdown")
+async def shutdown(ctx: Context):
+    ctx.logger.info(">>> Looper is shutting down.")
+
+
+async def coro():
+    while True:
+        print("doing hard work...")
+        await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    print("Starting the external loop from the agent or bureau...")
+    loop.create_task(coro())
+
+    # > when starting the external loop from the agent
+    agent.run()
+
+    # > when starting the external loop from the bureau
+    # bureau.run()

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -1150,6 +1150,7 @@ class Bureau:
         agents: Optional[List[Agent]] = None,
         port: Optional[int] = None,
         endpoint: Optional[Union[str, List[str], Dict[str, dict]]] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         log_level: Union[int, str] = logging.INFO,
     ):
         """
@@ -1160,7 +1161,10 @@ class Bureau:
             endpoint (Optional[Union[str, List[str], Dict[str, dict]]]): The endpoint configuration
             for the bureau.
         """
-        self._loop = asyncio.get_event_loop_policy().get_event_loop()
+        if loop is not None:
+            self._loop = loop
+        else:
+            self._loop = asyncio.get_event_loop_policy().get_event_loop()
         self._agents: List[Agent] = []
         self._endpoints = parse_endpoint_config(endpoint)
         self._port = port or 8000

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -290,10 +290,7 @@ class Agent(Sink):
             else GlobalResolver(max_endpoints=max_resolver_endpoints)
         )
 
-        if loop is not None:
-            self._loop = loop
-        else:
-            self._loop = asyncio.get_event_loop_policy().get_event_loop()
+        self._loop = loop or asyncio.get_event_loop_policy().get_event_loop()
 
         # initialize wallet and identity
         self._initialize_wallet_and_identity(seed, name, wallet_key_derivation_index)
@@ -1161,10 +1158,7 @@ class Bureau:
             endpoint (Optional[Union[str, List[str], Dict[str, dict]]]): The endpoint configuration
             for the bureau.
         """
-        if loop is not None:
-            self._loop = loop
-        else:
-            self._loop = asyncio.get_event_loop_policy().get_event_loop()
+        self._loop = loop or asyncio.get_event_loop_policy().get_event_loop()
         self._agents: List[Agent] = []
         self._endpoints = parse_endpoint_config(endpoint)
         self._port = port or 8000

--- a/python/src/uagents/mailbox.py
+++ b/python/src/uagents/mailbox.py
@@ -64,6 +64,12 @@ class MailboxClient:
 
     async def run(self):
         """
+        Runs the mailbox client.
+        """
+        await asyncio.gather(self.start_polling(), self.process_deletion_queue())
+
+    async def start_polling(self):
+        """
         Runs the mailbox client. Acquires an access token if needed and then starts a polling loop.
         """
         self._logger.info(f"Connecting to mailbox server at {self.base_url}")


### PR DESCRIPTION
## Proposed Changes

Add better support for adding agent tasks to be awaited by an external event loop using `await agent.run_async()`.

## Linked Issues

https://github.com/fetchai/uAgents/issues/475

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation

## Further comments
