### PR TITLE
fix(core): python version-safe datetime parsing and almanac api url refactor

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -284,11 +284,6 @@ class Agent(Sink):
         """
         self._name = name
         self._port = port if port is not None else 8000
-        self._resolver = (
-            resolve
-            if resolve is not None
-            else GlobalResolver(max_endpoints=max_resolver_endpoints)
-        )
 
         if loop is not None:
             self._loop = loop
@@ -325,6 +320,11 @@ class Agent(Sink):
             ]
         else:
             self._mailbox_client = None
+
+        self._resolver = resolve or GlobalResolver(
+            max_endpoints=max_resolver_endpoints,
+            almanac_api_url=f"{self._agentverse['http_prefix']}://{self._agentverse['base_url']}/v1/almanac/",
+        )
 
         self._ledger = get_ledger(test)
         self._almanac_contract = get_almanac_contract(test)

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -339,8 +339,9 @@ class InternalContext(Context):
         ):
             log(logger, logging.ERROR, f"Invalid protocol digest: {protocol_digest}")
             return []
+        almanac_api_url = getattr(self._resolver, "_almanac_api_url", ALMANAC_API_URL)
         response = requests.post(
-            url=ALMANAC_API_URL + "search",
+            url=almanac_api_url + "search",
             json={"text": protocol_digest[6:]},
             timeout=DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
         )

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -339,7 +339,11 @@ class InternalContext(Context):
         ):
             log(logger, logging.ERROR, f"Invalid protocol digest: {protocol_digest}")
             return []
-        almanac_api_url = getattr(self._resolver, "_almanac_api_url", ALMANAC_API_URL)
+        almanac_api_url = getattr(
+            getattr(self._resolver, "_almanac_api_resolver", None),
+            "_almanac_api_url",
+            ALMANAC_API_URL,
+        )
         response = requests.post(
             url=almanac_api_url + "search",
             json={"text": protocol_digest[6:]},

--- a/python/src/uagents/resolver.py
+++ b/python/src/uagents/resolver.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
+from dateutil import parser
 from uagents.config import (
     AGENT_ADDRESS_LENGTH,
     AGENT_PREFIX,
@@ -292,7 +293,7 @@ class AlmanacApiResolver(Resolver):
             if expiry_str is None:
                 return None, []
 
-            expiry = datetime.fromisoformat(expiry_str)
+            expiry = parser.parse(expiry_str)
             current_time = datetime.now(timezone.utc)
             endpoint_list = agent.get("endpoints", [])
 


### PR DESCRIPTION
## Proposed Changes

- Use `dateutil.parser` to allow datetimes with `Z` suffix, which breaks some older Python implementations of `datetime.fromisofromat()`.
- Build Almanac API url from agentverse config

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/cosmpy/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally