### PR TITLE
fix(core): check for env signature instead of trying to verify

### DIFF
--- a/python/src/uagents/communication.py
+++ b/python/src/uagents/communication.py
@@ -165,7 +165,7 @@ async def send_exchange_envelope(
                         if sync:
                             # If the message is synchronous but not verified, return the envelope
                             env = Envelope.model_validate(await resp.json())
-                            if not envelope.verify():
+                            if env.signature is None:
                                 return env
                             return await dispatch_sync_response_envelope(env)
                         return MsgStatus(
@@ -284,7 +284,7 @@ async def send_message_raw(
         sync=sync,
     )
     if isinstance(response, Envelope):
-        if not env.verify():
+        if env.signature is None:
             return response
         json_message = response.decode_payload()
         if response_type:


### PR DESCRIPTION
## Proposed Changes

Fixes synchronous responses, which were failing due to the new exception raised when envelope verification fails. Since all we want to know if whether the envelope is signed or not, we can replace the `if not env.verify()` check with `if env.signature is None`.

## Linked Issues
Fixes https://github.com/fetchai/uAgents/issues/502

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide 
- [x] Checks and tests pass locally