### PR TITLE
fix(core): asgi error message due to missing body

### DIFF
--- a/python/src/uagents/asgi.py
+++ b/python/src/uagents/asgi.py
@@ -135,6 +135,8 @@ class ASGIServer:
         header = (
             [[k.encode(), v.encode()] for k, v in headers.items()] if headers else None
         )
+        if body is None:
+            body = {}
 
         await send(
             {
@@ -143,10 +145,7 @@ class ASGIServer:
                 "headers": header or [[b"content-type", b"application/json"]],
             }
         )
-        if body:
-            await send(
-                {"type": "http.response.body", "body": json.dumps(body).encode()}
-            )
+        await send({"type": "http.response.body", "body": json.dumps(body).encode()})
 
     async def handle_readiness_probe(self, headers: CaseInsensitiveDict, send):
         """


### PR DESCRIPTION
A new bug was introduced in the last PR where you'll receive an error log message from the ASGI server due to an incomplete message.

`ERROR:    ASGI callable returned without completing response.`

These logs would be triggered whenever a message has been sent as the callee would send an incomplete acknowledgement.