### PR TITLE
feat(core): add agent metadata property

### DIFF
--- a/python/docs/api/uagents/agent.md
+++ b/python/docs/api/uagents/agent.md
@@ -160,6 +160,7 @@ An agent that interacts within a communication environment.
 - `_ctx` _Context_ - The context for agent interactions.
 - `_test` _bool_ - True if the agent will register and transact on the testnet.
 - `_enable_agent_inspector` _bool_ - Enable the agent inspector REST endpoints.
+- `_metadata` _Dict[str, Any]_ - Metadata associated with the agent.
   
   Properties:
 - `name` _str_ - The name of the agent.
@@ -172,6 +173,7 @@ An agent that interacts within a communication environment.
 - `mailbox_client` _MailboxClient_ - The client for interacting with the agentverse mailbox.
 - `protocols` _Dict[str, Protocol]_ - Dictionary mapping all supported protocol digests to their
   corresponding protocols.
+- `metadata` _Dict[str, Any]_ - Metadata associated with the agent.
 
 <a id="src.uagents.agent.Agent.__init__"></a>
 
@@ -193,7 +195,8 @@ def __init__(name: Optional[str] = None,
              test: bool = True,
              loop: Optional[asyncio.AbstractEventLoop] = None,
              log_level: Union[int, str] = logging.INFO,
-             enable_agent_inspector: bool = True)
+             enable_agent_inspector: bool = True,
+             metadata: Optional[Dict[str, Any]] = None)
 ```
 
 Initialize an Agent instance.
@@ -217,6 +220,7 @@ Initialize an Agent instance.
 - `loop` _Optional[asyncio.AbstractEventLoop]_ - The asyncio event loop to use.
 - `log_level` _Union[int, str]_ - The logging level for the agent.
 - `enable_agent_inspector` _bool_ - Enable the agent inspector for debugging.
+- `metadata` _Optional[Dict[str, Any]]_ - Optional metadata to include in the agent object.
 
 <a id="src.uagents.agent.Agent.initialize_wallet_messaging"></a>
 
@@ -384,6 +388,21 @@ Get the balance of the agent.
 **Returns**:
 
 - `int` - Bank balance.
+
+<a id="src.uagents.agent.Agent.metadata"></a>
+
+#### metadata
+
+```python
+@property
+def metadata() -> Dict[str, Any]
+```
+
+Get the metadata associated with the agent.
+
+**Returns**:
+
+  Dict[str, Any]: The metadata associated with the agent.
 
 <a id="src.uagents.agent.Agent.mailbox"></a>
 

--- a/python/docs/api/uagents/types.md
+++ b/python/docs/api/uagents/types.md
@@ -2,6 +2,25 @@
 
 # src.uagents.types
 
+<a id="src.uagents.types.AgentGeolocation"></a>
+
+## AgentGeolocation Objects
+
+```python
+class AgentGeolocation(BaseModel)
+```
+
+<a id="src.uagents.types.AgentGeolocation.serialize_precision"></a>
+
+#### serialize`_`precision
+
+```python
+@field_serializer("latitude", "longitude")
+def serialize_precision(val: float) -> float
+```
+
+Round the latitude and longitude to 6 decimal places.
+
 <a id="src.uagents.types.DeliveryStatus"></a>
 
 ## DeliveryStatus Objects

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -21,7 +21,7 @@ import requests
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet, PrivateKey
 from cosmpy.crypto.address import Address
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 
 from uagents.asgi import ASGIServer
 from uagents.communication import Dispenser
@@ -57,6 +57,7 @@ from uagents.storage import KeyValueStore, get_or_create_private_keys
 from uagents.types import (
     AgentEndpoint,
     AgentInfo,
+    AgentMetadata,
     EventCallback,
     IntervalCallback,
     JsonStr,
@@ -513,7 +514,9 @@ class Agent(Sink):
         else:
             self._wallet_messaging_client = None
 
-    def _initialize_metadata(self, metadata: Optional[Dict[str, Any]]):
+    def _initialize_metadata(
+        self, metadata: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         """
         Initialize the metadata for the agent.
 
@@ -521,18 +524,13 @@ class Agent(Sink):
         model ensures that the metadata is valid and complete.
 
         Args:
-            metadata (Dict[str, Any]): The metadata to include in the agent object.
+            metadata (Optional[Dict[str, Any]]): The metadata to include in the agent object.
+
+        Returns:
+            Dict[str, Any]: The filtered metadata.
         """
         if not metadata or "geolocation" not in metadata:
             return {}
-
-        class AgentGeolocation(BaseModel):
-            latitude: float
-            longitude: float
-            radius: int
-
-        class AgentMetadata(BaseModel):
-            geolocation: AgentGeolocation
 
         try:
             model = AgentMetadata.model_validate(metadata, strict=True)

--- a/python/src/uagents/envelope.py
+++ b/python/src/uagents/envelope.py
@@ -9,7 +9,6 @@ from typing import Callable, List, Optional
 from pydantic import (
     UUID4,
     BaseModel,
-    ConfigDict,
     Field,
     field_serializer,
 )
@@ -47,8 +46,6 @@ class Envelope(BaseModel):
     expires: Optional[int] = None
     nonce: Optional[int] = None
     signature: Optional[str] = None
-
-    model_config = ConfigDict(populate_by_name=True)
 
     def encode_payload(self, value: JsonStr):
         """

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 from cosmpy.aerial.client import LedgerClient
@@ -23,11 +23,22 @@ from uagents.network import AlmanacContract, InsufficientFundsError, add_testnet
 from uagents.types import AgentEndpoint
 
 
+def generate_backoff_time(retry: int) -> float:
+    """
+    Generate a backoff time starting from 0.128 seconds and limited to ~131 seconds
+    """
+    return (2 ** (min(retry, 11) + 6)) / 1000
+
+
 class AgentRegistrationPolicy(ABC):
     @abstractmethod
     # pylint: disable=unnecessary-pass
     async def register(
-        self, agent_address: str, protocols: List[str], endpoints: List[AgentEndpoint]
+        self,
+        agent_address: str,
+        protocols: List[str],
+        endpoints: List[AgentEndpoint],
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         pass
 
@@ -36,7 +47,7 @@ class AgentRegistrationAttestation(BaseModel):
     agent_address: str
     protocols: List[str]
     endpoints: List[AgentEndpoint]
-    metadata: Optional[Dict[str, Union[str, Dict[str, str]]]] = None
+    metadata: Optional[Dict[str, Any]] = None
     signature: Optional[str] = None
 
     def sign(self, identity: Identity):
@@ -84,11 +95,18 @@ class AlmanacApiRegistrationPolicy(AgentRegistrationPolicy):
         self._logger = logger or logging.getLogger(__name__)
 
     async def register(
-        self, agent_address: str, protocols: List[str], endpoints: List[AgentEndpoint]
+        self,
+        agent_address: str,
+        protocols: List[str],
+        endpoints: List[AgentEndpoint],
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         # create the attestation
         attestation = AgentRegistrationAttestation(
-            agent_address=agent_address, protocols=protocols, endpoints=endpoints
+            agent_address=agent_address,
+            protocols=protocols,
+            endpoints=endpoints,
+            metadata=metadata,
         )
 
         # sign the attestation
@@ -102,7 +120,9 @@ class AlmanacApiRegistrationPolicy(AgentRegistrationPolicy):
                         f"{self._almanac_api}/agents",
                         headers={"content-type": "application/json"},
                         data=attestation.model_dump_json(),
-                        timeout=ALMANAC_API_TIMEOUT_SECONDS,
+                        timeout=aiohttp.ClientTimeout(
+                            total=ALMANAC_API_TIMEOUT_SECONDS
+                        ),
                     ) as resp:
                         resp.raise_for_status()
                         self._logger.info("Registration on Almanac API successful")
@@ -110,11 +130,7 @@ class AlmanacApiRegistrationPolicy(AgentRegistrationPolicy):
                 except (aiohttp.ClientError, asyncio.exceptions.TimeoutError) as e:
                     if retry == self._max_retries - 1:
                         raise e
-
-                    # generate a backoff time starting from 0.128 seconds and limited
-                    # to ~131 seconds
-                    backoff = (2 ** (min(retry, 11) + 6)) / 1000
-                    await asyncio.sleep(backoff)
+                    await asyncio.sleep(generate_backoff_time(retry))
 
 
 class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
@@ -136,7 +152,11 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
         self._logger = logger or logging.getLogger(__name__)
 
     async def register(
-        self, agent_address: str, protocols: List[str], endpoints: List[AgentEndpoint]
+        self,
+        agent_address: str,
+        protocols: List[str],
+        endpoints: List[AgentEndpoint],
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         # register if not yet registered or registration is about to expire
         # or anything has changed from the last registration
@@ -223,10 +243,13 @@ class DefaultRegistrationPolicy(AgentRegistrationPolicy):
         agent_address: str,
         protocols: List[str],
         endpoints: List[AgentEndpoint],
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         # prefer the API registration policy as it is faster
         try:
-            await self._api_policy.register(agent_address, protocols, endpoints)
+            await self._api_policy.register(
+                agent_address, protocols, endpoints, metadata
+            )
         except Exception as e:
             self._logger.warning(
                 f"Failed to register on Almanac API: {e.__class__.__name__}"
@@ -234,7 +257,9 @@ class DefaultRegistrationPolicy(AgentRegistrationPolicy):
 
         # schedule the ledger registration
         try:
-            await self._ledger_policy.register(agent_address, protocols, endpoints)
+            await self._ledger_policy.register(
+                agent_address, protocols, endpoints, metadata
+            )
         except InsufficientFundsError:
             self._logger.warning(
                 "Failed to register on Almanac contract due to insufficient funds"

--- a/python/src/uagents/types.py
+++ b/python/src/uagents/types.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     Awaitable,
     Callable,
@@ -15,7 +16,7 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_serializer
 
 from uagents.models import Model
 
@@ -53,6 +54,30 @@ class RestHandlerDetails(BaseModel):
     endpoint: str
     request_model: Optional[Type[Model]] = None
     response_model: Type[Union[Model, BaseModel]]
+
+
+class AgentGeolocation(BaseModel):
+    latitude: Annotated[
+        float,
+        Field(strict=True, ge=-90, le=90, allow_inf_nan=False),
+    ]
+    longitude: Annotated[
+        float,
+        Field(strict=True, ge=-180, le=180, allow_inf_nan=False),
+    ]
+    radius: Annotated[
+        float,
+        Field(strict=True, ge=0, allow_inf_nan=False),
+    ] = 0
+
+    @field_serializer("latitude", "longitude")
+    def serialize_precision(self, val: float) -> float:
+        """Round the latitude and longitude to 6 decimal places."""
+        return float(f"{val:.6f}")
+
+
+class AgentMetadata(BaseModel):
+    geolocation: AgentGeolocation
 
 
 class DeliveryStatus(str, Enum):

--- a/python/tests/test_registration.py
+++ b/python/tests/test_registration.py
@@ -9,6 +9,7 @@ from uagents.registration import (
     AgentRegistrationAttestation,
     AlmanacApiRegistrationPolicy,
 )
+from uagents.types import AgentEndpoint
 
 
 def test_attestation_signature():
@@ -19,8 +20,8 @@ def test_attestation_signature():
         agent_address=identity.address,
         protocols=["foo", "bar", "baz"],
         endpoints=[
-            {"url": "https://foobar.com", "weight": 1},
-            {"url": "https://barbaz.com", "weight": 1},
+            AgentEndpoint(url="https://foobar.com", weight=1),
+            AgentEndpoint(url="https://barbaz.com", weight=1),
         ],
     )
 
@@ -40,8 +41,8 @@ def test_attestation_signature_with_metadata():
         agent_address=identity.address,
         protocols=["foo", "bar", "baz"],
         endpoints=[
-            {"url": "https://foobar.com", "weight": 1},
-            {"url": "https://barbaz.com", "weight": 1},
+            AgentEndpoint(url="https://foobar.com", weight=1),
+            AgentEndpoint(url="https://barbaz.com", weight=1),
         ],
         metadata={"foo": "bar", "baz": "42", "qux": {"a": "b", "c": "d"}},
     )


### PR DESCRIPTION
## Proposed Changes

Add metadata property to agent constructor.
The initial version will support metadata in the following form:
```python
class AgentGeolocation(BaseModel):
    latitude: float
    longitude: float
    radius: int

class AgentMetadata(BaseModel):
    geolocation: AgentGeolocation
```

Other metadata will be ignored which means the following agent will produce the respective output:
```python
agent = Agent(
    metadata={
        "geolocation": {
            "latitude": 52.507410,
            "longitude": 13.378240,
            "radius": 50,
        },
        "mobility": True,
        "useless_information": "This is a test",
    },
)
print(agent.metadata)
>>> {'geolocation': {'latitude': 52.50741, 'longitude': 13.37824, 'radius': 50}}
```

## Types of changes

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide 
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease
- [x] I have added/updated the documentation
