### PR TITLE
feat(core): add experimental rate limiter agent and protocol

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -393,7 +393,10 @@ class Agent(Sink):
             logger=self._logger,
         )
 
-        self._add_error_message_handler()
+        # define default error message handler
+        @self.on_message(ErrorMessage)
+        async def _handle_error_message(ctx: Context, sender: str, msg: ErrorMessage):
+            ctx.logger.exception(f"Received error message from {sender}: {msg.error}")
 
         # define default rest message handlers if agent inspector is enabled
         if enable_agent_inspector:
@@ -413,12 +416,6 @@ class Agent(Sink):
         self._enable_agent_inspector = enable_agent_inspector
 
         self._init_done = True
-
-    def _add_error_message_handler(self):
-        # define default error message handler
-        @self.on_message(ErrorMessage)
-        async def _handle_error_message(ctx: Context, sender: str, msg: ErrorMessage):
-            ctx.logger.exception(f"Received error message from {sender}: {msg.error}")
 
     def _build_context(self) -> InternalContext:
         """

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -393,10 +393,7 @@ class Agent(Sink):
             logger=self._logger,
         )
 
-        # define default error message handler
-        @self.on_message(ErrorMessage)
-        async def _handle_error_message(ctx: Context, sender: str, msg: ErrorMessage):
-            ctx.logger.exception(f"Received error message from {sender}: {msg.error}")
+        self._add_error_message_handler()
 
         # define default rest message handlers if agent inspector is enabled
         if enable_agent_inspector:
@@ -416,6 +413,12 @@ class Agent(Sink):
         self._enable_agent_inspector = enable_agent_inspector
 
         self._init_done = True
+
+    def _add_error_message_handler(self):
+        # define default error message handler
+        @self.on_message(ErrorMessage)
+        async def _handle_error_message(ctx: Context, sender: str, msg: ErrorMessage):
+            ctx.logger.exception(f"Received error message from {sender}: {msg.error}")
 
     def _build_context(self) -> InternalContext:
         """

--- a/python/src/uagents/experimental/quota/__init__.py
+++ b/python/src/uagents/experimental/quota/__init__.py
@@ -24,7 +24,8 @@ async def handle(ctx: Context, sender: str, msg: ExampleMessage):
     ...
 ```
 
-Also applies to protocol message handlers if you import the QuotaProtocol class:
+Also applies to protocol message handlers if you import the QuotaProtocol class
+and use it with the Quota agents callback function:
 ```python
 protocol = QuotaProtocol(
     quota_callback=agent.add_request,

--- a/python/src/uagents/experimental/quota/__init__.py
+++ b/python/src/uagents/experimental/quota/__init__.py
@@ -202,7 +202,7 @@ class QuotaProtocol(Protocol):
                         error=(
                             f"Rate limit exceeded for {msg.schema()["title"]}. "
                             f"This endpoint allows for {rate_limit.max_requests} calls per "
-                            f"{rate_limit. window_size_minutes} minutes. Try again later."
+                            f"{rate_limit.window_size_minutes} minutes. Try again later."
                         )
                     ),
                 )

--- a/python/src/uagents/experimental/quota/__init__.py
+++ b/python/src/uagents/experimental/quota/__init__.py
@@ -1,0 +1,244 @@
+"""
+This agent class can be used to rate limit your message handlers.
+
+The rate limiter uses the agents storage to keep track of the number of requests
+made by another agent within a given time window. If the number of requests exceeds
+a specified limit, the rate limiter will block further requests until the time
+window resets.
+
+> Default: 6 requests per hour
+
+Usage examples:
+
+This message handler is rate limited with default values:
+```python
+@agent.on_message(ExampleMessage)
+async def handle(ctx: Context, sender: str, msg: ExampleMessage):
+    ...
+```
+
+This message handler is rate limited with custom window size and request limit:
+```python
+@agent.on_message(ExampleMessage, window_size_minutes=30, max_requests=10)
+async def handle(ctx: Context, sender: str, msg: ExampleMessage):
+    ...
+```
+
+Also applies to protocol message handlers if you import the QuotaProtocol class:
+```python
+protocol = QuotaProtocol(
+    quota_callback=agent.add_request,
+    name="quota_proto",
+    version=agent._version,
+)
+
+@protocol.on_message(ExampleMessage)
+async def handle(ctx: Context, sender: str, msg: ExampleMessage):
+    ...
+
+agent.include(protocol)
+```
+"""
+
+import functools
+import time
+from typing import Callable, Optional, Set, Type, Union
+
+from pydantic import BaseModel
+
+from uagents import Agent, Context, Model, Protocol
+from uagents.models import ErrorMessage
+from uagents.types import MessageCallback
+
+WINDOW_SIZE_MINUTES = 60
+MAX_REQUESTS = 6
+
+
+class Usage(BaseModel):
+    time_window_start: float
+    window_size_minutes: int
+    requests: int
+    max_requests: int
+
+
+class QuotaProtocol(Protocol):
+    def __init__(self, quota_callback: Callable, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.quota_callback = quota_callback
+
+    def on_message(
+        self,
+        model: Type[Model],
+        replies: Optional[Union[Type[Model], Set[Type[Model]]]] = None,
+        allow_unverified: Optional[bool] = False,
+        window_size_minutes: int = WINDOW_SIZE_MINUTES,
+        max_requests: int = MAX_REQUESTS,
+    ):
+        """
+        Overwritten decorator to register a message handler for the protocol
+        including rate limiting.
+
+        Args:
+            model (Type[Model]): The message model type.
+            replies (Optional[Union[Type[Model], Set[Type[Model]]]], optional): The associated
+            reply types. Defaults to None.
+            allow_unverified (Optional[bool], optional): Whether to allow unverified messages.
+            Defaults to False.
+            window_size_minutes (int, optional): The size of the time window in minutes.
+            max_requests (int, optional): The maximum number of requests allowed in the time window.
+
+        Returns:
+            Callable: The decorator to register the message handler.
+        """
+
+        def decorator_on_message(func: MessageCallback):
+            handler = self.wrap(func, window_size_minutes, max_requests)
+            self._add_message_handler(model, handler, replies, allow_unverified)
+            return handler
+
+        return decorator_on_message
+
+    def wrap(
+        self,
+        func: MessageCallback,
+        window_size_minutes: int = WINDOW_SIZE_MINUTES,
+        max_requests: int = MAX_REQUESTS,
+    ) -> MessageCallback:
+        """
+        Decorator to wrap a function with rate limiting.
+
+        Args:
+            func: The function to wrap with rate limiting
+            window_size_minutes: The size of the time window in minutes
+            max_requests: The maximum number of requests allowed in the time window
+
+        Returns:
+            Callable: The decorated
+        """
+
+        @functools.wraps(func)
+        async def decorator(ctx: Context, sender: str, msg: Type[Model]):
+            if self.quota_callback(
+                sender, func.__name__, window_size_minutes, max_requests
+            ):
+                result = await func(ctx, sender, msg)
+            else:
+                result = await ctx.send(
+                    sender,
+                    ErrorMessage(
+                        error=(
+                            f"Rate limit exceeded for {msg.schema()["title"]}. "
+                            f"This endpoint allows for {max_requests} calls per "
+                            f"{window_size_minutes} minutes. Try again later."
+                        )
+                    ),
+                )
+            return result
+
+        return decorator  # type: ignore
+
+
+class QuotaAgent(Agent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._protocol = QuotaProtocol(
+            quota_callback=self.add_request, name=self._name, version=self._version
+        )
+
+        # only necessary because this feature is not implemented in the core
+        @self.on_message(ErrorMessage)
+        async def _handle_error_message(ctx: Context, sender: str, msg: ErrorMessage):
+            ctx.logger.exception(f"Received error message from {sender}: {msg.error}")
+
+    def on_message(
+        self,
+        model: Type[Model],
+        replies: Optional[Union[Type[Model], Set[Type[Model]]]] = None,
+        allow_unverified: Optional[bool] = False,
+        window_size_minutes: int = WINDOW_SIZE_MINUTES,
+        max_requests: int = MAX_REQUESTS,
+    ):
+        """
+        Overwritten decorator to register an message handler for the provided
+        message model including rate limiting.
+
+        Args:
+            model (Type[Model]): The message model.
+            replies (Optional[Union[Type[Model], Set[Type[Model]]]]): Optional reply models.
+            allow_unverified (Optional[bool]): Allow unverified messages.
+            window_size_minutes (int): The size of the time window in minutes.
+            max_requests (int): The maximum number of requests allowed in the time window.
+
+        Returns:
+            Callable: The decorator function for registering message handlers.
+
+        """
+
+        return self._protocol.on_message(
+            model, replies, allow_unverified, window_size_minutes, max_requests
+        )
+
+    def _add_error_message_handler(self):
+        # This would not be necessary if this feature was implemented in the core
+        pass
+
+    def _clean_usage(self, usage: dict[str, dict]):
+        """
+        Remove all time windows that are older than the current time window.
+
+        Args:
+            usage: The usage dictionary to clean
+        """
+        now = int(time.time())
+        for key in list(usage.keys()):
+            if (now - usage[key]["time_window_start"]) > usage[key][
+                "window_size_minutes"
+            ] * 60:
+                del usage[key]
+
+    def add_request(
+        self,
+        agent_address: str,
+        function_name: str,
+        window_size_minutes: int,
+        max_requests: int,
+    ) -> bool:
+        """
+        Add a request to the rate limiter if the current time is still within the
+        time window since the beginning of the most recent time window. Otherwise,
+        reset the time window and add the request.
+
+        Args:
+            agent_address: The address of the agent making the request
+
+        Returns:
+            False if the maximum number of requests has been exceeded, True otherwise
+        """
+
+        now = int(time.time())
+
+        usage = self.storage.get(agent_address) or {}
+
+        if function_name in usage:
+            quota = Usage(**usage[function_name])
+            if (now - quota.time_window_start) <= window_size_minutes * 60:
+                if quota.requests >= max_requests:
+                    return False
+                quota.requests += 1
+            else:
+                quota.time_window_start = now
+                quota.requests = 1
+            usage[function_name] = quota.model_dump()
+        else:
+            usage[function_name] = Usage(
+                time_window_start=now,
+                window_size_minutes=window_size_minutes,
+                requests=1,
+                max_requests=max_requests,
+            ).model_dump()
+
+        self._clean_usage(usage)
+
+        self.storage.set(agent_address, usage)
+
+        return True


### PR DESCRIPTION
## Proposed Changes

This Protocol class can be used to rate limit `on_message` message handlers.

The rate limiter uses the agents storage to keep track of the number of requests made by another agent within a given time window. If the number of requests exceeds a specified limit, the rate limiter will block further requests until the time window resets.

> Default: Not rate limited, but you can set a default during initialization.

Additionally, the protocol can be used to set access control rules for handlers allowing or blocking specific agents from accessing the handler. The default access control rule can be set to allow or block all agents.

Both rules can work together to provide a secure and rate-limited environment for message handlers.


Usage examples:

```python
from uagents.experimental.quota import AccessControlList, QuotaProtocol, RateLimit

# Initialize the QuotaProtocol instance
quota_protocol = QuotaProtocol(
    storage_reference=agent.storage,
    name="quota_proto",
    version=agent._version,
    # default_rate_limit=RateLimit(window_size_minutes=1, max_requests=3), # Optional
) 

# This message handler is not rate limited
@quota_protocol.on_message(ExampleMessage1)
async def handle(ctx: Context, sender: str, msg: ExampleMessage1):
    ...

# This message handler is rate limited with custom window size and request limit
@quota_protocol.on_message(ExampleMessage2, rate_limit=RateLimit(window_size_minutes=1, max_requests=3))
async def handle(ctx: Context, sender: str, msg: ExampleMessage2):
    ...

# This message handler has access control rules set
@quota_protocol.on_message(ExampleMessage3, acl=AccessControlList(default=False, allowed={"<agent_address>"}))
async def handle(ctx: Context, sender: str, msg: ExampleMessage3):
    ...

agent.include(quota_protocol)
```

**Tip:** The `AccessControlList` object can be used to set access control rules during runtime. This can be useful for dynamic access control rules based on the state of the agent or the network.
```python
acl = AccessControlList(default=True, allowed={""}, blocked={""})

@proto.on_message(model=Message, access_control_list=acl)
async def message_handler(ctx: Context, sender: str, msg: Message):
    if REASON_TO_BLOCK:
        acl.blocked.add(sender)
    ctx.logger.info(f"Received message from {sender}: {msg.text}")
```

## Types of changes

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide 
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation
