### PR TITLE
feat(core): integrate domain + full agent address in Envelope and handler

### DIFF
--- a/python/examples/13-agent-name-service/agent1.py
+++ b/python/examples/13-agent-name-service/agent1.py
@@ -10,8 +10,11 @@ class Message(Model):
     message: str
 
 
+DOMAIN = "example.agent"
+
 bob = Agent(
     name="bob-0",
+    domain=DOMAIN,
     seed="agent bob-0 secret phrase",
     port=8001,
     endpoint=["http://localhost:8001/submit"],

--- a/python/examples/13-agent-name-service/agent1.py
+++ b/python/examples/13-agent-name-service/agent1.py
@@ -7,7 +7,7 @@ from uagents.network import get_faucet, get_name_service_contract, logger
 
 
 class Message(Model):
-    message: str
+    text: str
 
 
 DOMAIN = "bob.example.agent"
@@ -39,7 +39,7 @@ async def register_agent_name(ctx: Context):
 
 @bob.on_message(model=Message)
 async def message_handler(ctx: Context, sender: str, msg: Message):
-    ctx.logger.info(f"Received message from {sender}: {msg.message}")
+    ctx.logger.info(f"Received message from {sender}: {msg.text}")
 
 
 if __name__ == "__main__":

--- a/python/examples/13-agent-name-service/agent1.py
+++ b/python/examples/13-agent-name-service/agent1.py
@@ -10,10 +10,10 @@ class Message(Model):
     message: str
 
 
-DOMAIN = "example.agent"
+DOMAIN = "bob.example.agent"
 
 bob = Agent(
-    name="bob-0",
+    name="bob",
     domain=DOMAIN,
     seed="agent bob-0 secret phrase",
     port=8001,
@@ -24,7 +24,6 @@ bob = Agent(
 my_wallet = LocalWallet.from_unsafe_seed("registration test wallet")
 name_service_contract = get_name_service_contract(test=True)
 faucet = get_faucet()
-DOMAIN = "example.agent"
 
 logger.info(f"Adding testnet funds to {my_wallet.address()}...")
 faucet.get_wealth(my_wallet.address())

--- a/python/examples/13-agent-name-service/agent2.py
+++ b/python/examples/13-agent-name-service/agent2.py
@@ -2,24 +2,24 @@ from uagents import Agent, Context, Model
 
 
 class Message(Model):
-    message: str
+    text: str
 
 
 alice = Agent(
-    name="alice-0",
+    name="alice",
     seed="agent alice-0 secret phrase",
     port=8000,
     endpoint=["http://localhost:8000/submit"],
 )
 
-DOMAIN = "example.agent"
+DOMAIN = "bob.example.agent"
 
 
 @alice.on_interval(period=5)
 async def alice_interval_handler(ctx: Context):
-    bob_name = "bob-0" + "." + DOMAIN
+    bob_name = DOMAIN
     ctx.logger.info(f"Sending message to {bob_name}...")
-    await ctx.send(bob_name, Message(message="Hello there bob."))
+    await ctx.send(bob_name, Message(text="Hello there bob."))
 
 
 if __name__ == "__main__":

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -16,6 +16,7 @@ from typing import (
     Type,
     Union,
 )
+from urllib.parse import quote
 
 import requests
 from cosmpy.aerial.client import LedgerClient
@@ -1193,7 +1194,7 @@ class Agent(Sink):
                 f"{self._agentverse['http_prefix']}://{self._agentverse['base_url']}"
             )
             inspector_url = f"{agentverse_url}/inspect/"
-            escaped_uri = requests.utils.compat.quote(f"http://127.0.0.1:{self._port}")
+            escaped_uri = quote(f"http://127.0.0.1:{self._port}")
             self._logger.info(
                 f"Agent inspector available at {inspector_url}"
                 f"?uri={escaped_uri}&address={self.address}"

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -817,7 +817,7 @@ class Agent(Sink):
                 if get_agent_address(self._domain, self._test) == self.address:
                     return
                 self._logger.warning(
-                    f"Agent address {self.address} is not registered domain {self._domain}. "
+                    f"Agent address {self.address} is not registered to domain {self._domain}. "
                 )
                 self._domain = None
             except Exception:

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -1193,7 +1193,7 @@ class Agent(Sink):
                 f"{self._agentverse['http_prefix']}://{self._agentverse['base_url']}"
             )
             inspector_url = f"{agentverse_url}/inspect/"
-            escaped_uri = requests.utils.quote(f"http://127.0.0.1:{self._port}")
+            escaped_uri = requests.utils.compat.quote(f"http://127.0.0.1:{self._port}")
             self._logger.info(
                 f"Agent inspector available at {inspector_url}"
                 f"?uri={escaped_uri}&address={self.address}"

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -54,7 +54,12 @@ from uagents.registration import (
     DefaultRegistrationPolicy,
     update_agent_status,
 )
-from uagents.resolver import GlobalResolver, Resolver, get_agent_address
+from uagents.resolver import (
+    GlobalResolver,
+    Resolver,
+    get_agent_address,
+    parse_identifier,
+)
 from uagents.storage import KeyValueStore, get_or_create_private_keys
 from uagents.types import (
     AgentEndpoint,
@@ -148,6 +153,7 @@ class AgentRepresentation:
     def __init__(
         self,
         address: str,
+        identifier: str,
         name: Optional[str],
         signing_callback: Callable,
     ):
@@ -160,6 +166,7 @@ class AgentRepresentation:
             signing_callback (Callable): The callback for signing messages.
         """
         self._address = address
+        self._identifier = identifier
         self._name = name
         self._signing_callback = signing_callback
 
@@ -193,7 +200,7 @@ class AgentRepresentation:
         Returns:
             str: The agent's address and network prefix.
         """
-        return TESTNET_PREFIX + "://" + self._address
+        return self._identifier
 
     def sign_digest(self, data: bytes) -> str:
         """
@@ -441,6 +448,7 @@ class Agent(Sink):
         return InternalContext(
             agent=AgentRepresentation(
                 address=self.address,
+                identifier=self.identifier,
                 name=self._name,
                 signing_callback=self._identity.sign_digest,
             ),
@@ -584,7 +592,8 @@ class Agent(Sink):
             str: The agent's identifier.
         """
         prefix = TESTNET_PREFIX if self._test else MAINNET_PREFIX
-        return prefix + "://" + self._identity.address
+        domain = f"{self._domain}/" if self._domain else ""
+        return prefix + "://" + domain + self._identity.address
 
     @property
     def wallet(self) -> LocalWallet:
@@ -1249,6 +1258,8 @@ class Agent(Sink):
             # get an element from the queue
             schema_digest, sender, message, session = await self._message_queue.get()
 
+            _, _, parsed_address = parse_identifier(sender)
+
             # lookup the model definition
             model_class: Optional[Type[Model]] = self._models.get(schema_digest)
             if model_class is None:
@@ -1263,7 +1274,7 @@ class Agent(Sink):
             self._message_cache.add_entry(
                 EnvelopeHistoryEntry(
                     version=1,
-                    sender=sender,
+                    sender=parsed_address,
                     target=self.address,
                     session=session,
                     schema_digest=schema_digest,
@@ -1275,6 +1286,7 @@ class Agent(Sink):
             context = ExternalContext(
                 agent=AgentRepresentation(
                     address=self.address,
+                    identifier=self.identifier,
                     name=self._name,
                     signing_callback=self._identity.sign_digest,
                 ),
@@ -1305,7 +1317,7 @@ class Agent(Sink):
                 self._logger.warning(f"Unable to parse message: {ex}")
                 await _send_error_message(
                     context,
-                    sender,
+                    parsed_address,
                     ErrorMessage(
                         error=f"Message does not conform to expected schema: {ex}"
                     ),
@@ -1317,12 +1329,12 @@ class Agent(Sink):
                 schema_digest
             )
             if handler is None:
-                if not is_user_address(sender):
+                if not is_user_address(parsed_address):
                     handler = self._signed_message_handlers.get(schema_digest)
                 elif schema_digest in self._signed_message_handlers:
                     await _send_error_message(
                         context,
-                        sender,
+                        parsed_address,
                         ErrorMessage(
                             error="Message must be sent from verified agent address"
                         ),

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -494,7 +494,7 @@ class InternalContext(Context):
         # Handle external dispatch of messages
         env = Envelope(
             version=1,
-            sender=self.agent.address,
+            sender=self.agent.identifier,
             target=destination_address,
             session=self._session,
             schema_digest=message_schema_digest,

--- a/python/src/uagents/envelope.py
+++ b/python/src/uagents/envelope.py
@@ -14,6 +14,7 @@ from pydantic import (
 )
 
 from uagents.crypto import Identity
+from uagents.resolver import parse_identifier
 from uagents.types import JsonStr
 
 
@@ -93,7 +94,8 @@ class Envelope(BaseModel):
         """
         if self.signature is None:
             raise ValueError("Envelope signature is missing")
-        return Identity.verify_digest(self.sender, self._digest(), self.signature)
+        _, _, parsed_address = parse_identifier(self.sender)
+        return Identity.verify_digest(parsed_address, self._digest(), self.signature)
 
     def _digest(self) -> bytes:
         """


### PR DESCRIPTION
## Proposed Changes

This PR will enable users to set the domain name of an agent they have registered. The `domain` parameter will be set once the agent has started and successfully verified that the domain actually belongs to this agent.

In subsequent messages the agent will use this domain as well as the prefix when sending messages, i.e. it will be part of the Envelope and available in the message handler through the `sender` variable.

## Types of changes

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

This needs to be tested for Agentverse compatibility.