### PR TITLE
feat(core): add name and protocol info to attestation

### DIFF
--- a/python/docs/api/uagents/protocol.md
+++ b/python/docs/api/uagents/protocol.md
@@ -183,6 +183,21 @@ Property to access the digest of the protocol's manifest.
 
 - `str` - The digest of the protocol's manifest.
 
+<a id="src.uagents.protocol.Protocol.info"></a>
+
+#### info
+
+```python
+@property
+def info()
+```
+
+Property to access the protocol details.
+
+**Returns**:
+
+- `ProtocolDetails` - The protocol details.
+
 <a id="src.uagents.protocol.Protocol.on_interval"></a>
 
 #### on`_`interval

--- a/python/docs/api/uagents/registration.md
+++ b/python/docs/api/uagents/registration.md
@@ -2,6 +2,20 @@
 
 # src.uagents.registration
 
+<a id="src.uagents.registration.AgentRegistrationAttestation"></a>
+
+## AgentRegistrationAttestation Objects
+
+```python
+class AgentRegistrationAttestation(VerifiableModel)
+```
+
+<a id="src.uagents.registration.AgentRegistrationAttestation.protocols"></a>
+
+#### protocols
+
+str for backwards compatibility
+
 <a id="src.uagents.registration.generate_backoff_time"></a>
 
 #### generate`_`backoff`_`time
@@ -59,10 +73,7 @@ if it is different from the supported version.
 #### register
 
 ```python
-async def register(agent_address: str,
-                   protocols: List[str],
-                   endpoints: List[AgentEndpoint],
-                   metadata: Optional[Dict[str, Any]] = None)
+async def register(agent_info: AgentInfo)
 ```
 
 Register the agent on the Almanac contract if registration is about to expire or

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -406,11 +406,7 @@ class Agent(Sink):
 
             @self.on_rest_get("/agent_info", AgentInfo)  # type: ignore
             async def _handle_get_info(_ctx: Context):
-                return AgentInfo(
-                    agent_address=self.address,
-                    endpoints=self._endpoints,
-                    protocols=list(self.protocols.keys()),
-                )
+                return self.info
 
             @self.on_rest_get("/messages", EnvelopeHistory)  # type: ignore
             async def _handle_get_messages(_ctx: Context):
@@ -647,8 +643,9 @@ class Agent(Sink):
         """
         return AgentInfo(
             agent_address=self.address,
+            agent_name=self._name or "",
             endpoints=self._endpoints,
-            protocols=list(self.protocols.keys()),
+            protocols=[p.info for p in self.protocols.values()],
             metadata=self.metadata,
         )
 
@@ -788,9 +785,7 @@ class Agent(Sink):
         """
         assert self._registration_policy is not None, "Agent has no registration policy"
 
-        await self._registration_policy.register(
-            self.address, list(self.protocols.keys()), self._endpoints, self._metadata
-        )
+        await self._registration_policy.register(self.info)
 
     async def _schedule_registration(self):
         """

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -20,6 +20,7 @@ from cosmpy.aerial.tx import Transaction
 from cosmpy.aerial.tx_helpers import TxResponse
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.address import Address
+from pydantic import BaseModel
 
 from uagents.config import (
     ALMANAC_CONTRACT_VERSION,
@@ -33,7 +34,7 @@ from uagents.config import (
     TESTNET_CONTRACT_NAME_SERVICE,
 )
 from uagents.crypto import Identity
-from uagents.types import AgentEndpoint, AgentInfo
+from uagents.types import AgentEndpoint
 from uagents.utils import get_logger
 
 logger = get_logger("network")
@@ -48,7 +49,10 @@ class InsufficientFundsError(Exception):
     """Raised when an agent has insufficient funds for a transaction."""
 
 
-class AlmanacContractRecord(AgentInfo):
+class AlmanacContractRecord(BaseModel):
+    agent_address: str
+    protocols: List[str]
+    endpoints: List[AgentEndpoint]
     contract_address: str
     sender_address: str
     timestamp: Optional[int] = None

--- a/python/src/uagents/protocol.py
+++ b/python/src/uagents/protocol.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 from apispec import APISpec
 
 from uagents.models import Model
-from uagents.types import IntervalCallback, MessageCallback
+from uagents.types import IntervalCallback, MessageCallback, ProtocolDetails
 
 OPENAPI_VERSION = "3.0.2"
 
@@ -148,6 +148,18 @@ class Protocol:
             str: The digest of the protocol's manifest.
         """
         return self.manifest()["metadata"]["digest"]
+
+    @property
+    def info(self):
+        """
+        Property to access the protocol details.
+
+        Returns:
+            ProtocolDetails: The protocol details.
+        """
+        return ProtocolDetails(
+            name=self._name, version=self._version, digest=self.digest
+        )
 
     def on_interval(
         self,

--- a/python/src/uagents/types.py
+++ b/python/src/uagents/types.py
@@ -43,10 +43,17 @@ class AgentEndpoint(BaseModel):
     weight: int
 
 
+class ProtocolDetails(BaseModel):
+    name: str
+    version: str
+    digest: str
+
+
 class AgentInfo(BaseModel):
     agent_address: str
+    agent_name: str = ""
+    protocols: List[ProtocolDetails]
     endpoints: List[AgentEndpoint]
-    protocols: List[str]
     metadata: Optional[Dict[str, Any]] = None
 
 


### PR DESCRIPTION
## Proposed Changes

Extend the `AgentRegistrationAttestation` with agent name and protocol info to be available in Agentverse.

## Types of changes

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
