### PR TITLE
chore(core): always return envelope on sync responses

### DIFF
--- a/python/docs/api/uagents/communication.md
+++ b/python/docs/api/uagents/communication.md
@@ -80,17 +80,6 @@ Method to send an exchange envelope.
 
   Union[MsgStatus, Envelope]: Either the status of the message or the response envelope.
 
-<a id="src.uagents.communication.dispatch_sync_response_envelope"></a>
-
-#### dispatch`_`sync`_`response`_`envelope
-
-```python
-async def dispatch_sync_response_envelope(
-        env: Envelope) -> Union[MsgStatus, Envelope]
-```
-
-Dispatch a synchronous response envelope locally.
-
 <a id="src.uagents.communication.send_message_raw"></a>
 
 #### send`_`message`_`raw

--- a/python/docs/api/uagents/context.md
+++ b/python/docs/api/uagents/context.md
@@ -315,10 +315,12 @@ Please use the `ctx.agent.address` property instead.
 #### send
 
 ```python
-async def send(destination: str,
-               message: Model,
-               sync: bool = False,
-               timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS) -> MsgStatus
+async def send(
+    destination: str,
+    message: Model,
+    sync: bool = False,
+    timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS
+) -> Union[MsgStatus, Envelope]
 ```
 
 This is the pro-active send method which is used in on_event and

--- a/python/docs/api/uagents/context.md
+++ b/python/docs/api/uagents/context.md
@@ -376,10 +376,12 @@ Initialize the ExternalContext instance and attributes needed from the InternalC
 #### send
 
 ```python
-async def send(destination: str,
-               message: Model,
-               sync: bool = False,
-               timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS) -> MsgStatus
+async def send(
+    destination: str,
+    message: Model,
+    sync: bool = False,
+    timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS
+) -> Union[MsgStatus, Envelope]
 ```
 
 Send a message to the specified destination.

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -442,6 +442,7 @@ class Agent(Sink):
             interval_messages=self._interval_messages,
             wallet_messaging_client=self._wallet_messaging_client,
             logger=self._logger,
+            models=self._models,
         )
 
     def _initialize_wallet_and_identity(self, seed, name, wallet_key_derivation_index):

--- a/python/src/uagents/asgi.py
+++ b/python/src/uagents/asgi.py
@@ -18,7 +18,7 @@ from pydantic.v1.error_wrappers import ErrorWrapper
 from requests.structures import CaseInsensitiveDict
 
 from uagents.communication import enclose_response_raw
-from uagents.config import RESPONSE_TIME_HINT_SECONDS
+from uagents.config import DEFAULT_ENVELOPE_TIMEOUT_SECONDS, RESPONSE_TIME_HINT_SECONDS
 from uagents.context import ERROR_MESSAGE_DIGEST
 from uagents.crypto import is_user_address
 from uagents.dispatch import dispatcher
@@ -361,7 +361,9 @@ class ASGIServer:
 
         # wait for any queries to be resolved
         if expects_response:
-            response_msg, schema_digest = await self._queries[env.sender]
+            response_msg, schema_digest = await asyncio.wait_for(
+                self._queries[env.sender], DEFAULT_ENVELOPE_TIMEOUT_SECONDS
+            )
             if (env.expires is not None) and (
                 datetime.now() > datetime.fromtimestamp(env.expires)
             ):

--- a/python/src/uagents/asgi.py
+++ b/python/src/uagents/asgi.py
@@ -364,12 +364,12 @@ class ASGIServer:
             timeout = (
                 env.expires - datetime.now(timezone.utc).timestamp()
                 if env.expires
-                else None
+                else DEFAULT_ENVELOPE_TIMEOUT_SECONDS
             )
             try:
                 response_msg, schema_digest = await asyncio.wait_for(
                     self._queries[env.sender],
-                    timeout or DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
+                    timeout,
                 )
             except asyncio.TimeoutError:
                 response_msg = ErrorMessage(

--- a/python/src/uagents/communication.py
+++ b/python/src/uagents/communication.py
@@ -138,7 +138,7 @@ async def send_exchange_envelope(
                                     )
                                 if not verified:
                                     continue
-                            return await dispatch_sync_response_envelope(env)
+                            return env
                         return MsgStatus(
                             status=DeliveryStatus.DELIVERED,
                             detail="Message successfully delivered via HTTP",
@@ -162,27 +162,6 @@ async def send_exchange_envelope(
         destination=envelope.target,
         endpoint="",
         session=envelope.session,
-    )
-
-
-async def dispatch_sync_response_envelope(env: Envelope) -> Union[MsgStatus, Envelope]:
-    """Dispatch a synchronous response envelope locally."""
-    # If there are no sinks registered, return the envelope back to the caller
-    if len(dispatcher.sinks) == 0:
-        return env
-    await dispatcher.dispatch_msg(
-        env.sender,
-        env.target,
-        env.schema_digest,
-        env.decode_payload(),
-        env.session,
-    )
-    return MsgStatus(
-        status=DeliveryStatus.DELIVERED,
-        detail="Sync message successfully delivered via HTTP",
-        destination=env.target,
-        endpoint="",
-        session=env.session,
     )
 
 

--- a/python/src/uagents/communication.py
+++ b/python/src/uagents/communication.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import uuid
-from time import time
+from datetime import datetime, timezone
 from typing import List, Optional, Tuple, Type, Union
 
 import aiohttp
@@ -222,7 +222,7 @@ async def send_message_raw(
         target=destination_address,
         session=uuid.uuid4(),
         schema_digest=message_schema_digest,
-        expires=int(time()) + timeout,
+        expires=int(datetime.now(timezone.utc).timestamp()) + timeout,
     )
     env.encode_payload(message_body)
     if not is_user_address(sender_address) and isinstance(sender, Identity):

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -27,7 +27,6 @@ from typing_extensions import deprecated
 from uagents.communication import (
     Dispenser,
     dispatch_local_message,
-    dispatch_sync_response_envelope,
 )
 from uagents.config import (
     ALMANAC_API_URL,
@@ -382,7 +381,8 @@ class InternalContext(Context):
             ]
         )
         log(self.logger, logging.DEBUG, f"Sent {len(futures)} messages")
-        return futures
+
+        return futures  # type: ignore
 
     def _is_valid_interval_message(self, schema_digest: str) -> bool:
         """
@@ -404,7 +404,7 @@ class InternalContext(Context):
         message: Model,
         sync: bool = False,
         timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
-    ) -> MsgStatus:
+    ) -> Union[MsgStatus, Envelope]:
         """
         This is the pro-active send method which is used in on_event and
         on_interval methods. In these methods, interval messages are set but
@@ -441,7 +441,7 @@ class InternalContext(Context):
         timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
         protocol_digest: Optional[str] = None,
         queries: Optional[Dict[str, asyncio.Future]] = None,
-    ) -> MsgStatus:
+    ) -> Union[MsgStatus, Envelope]:
         # Extract address from destination agent identifier if present
         _, parsed_name, parsed_address = parse_identifier(destination)
 
@@ -520,9 +520,6 @@ class InternalContext(Context):
                 endpoint="",
                 session=self._session,
             )
-
-        if isinstance(result, Envelope):
-            return await dispatch_sync_response_envelope(result)
 
         return result
 

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import uuid
 from abc import ABC, abstractmethod
-from time import time
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -489,7 +489,7 @@ class InternalContext(Context):
             )
 
         # Calculate when the envelope expires
-        expires = int(time()) + timeout
+        expires = int(datetime.now(timezone.utc).timestamp()) + timeout
 
         # Handle external dispatch of messages
         env = Envelope(

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -623,7 +623,7 @@ class ExternalContext(InternalContext):
         message: Model,
         sync: bool = False,
         timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
-    ) -> MsgStatus:
+    ) -> Union[MsgStatus, Envelope]:
         """
         Send a message to the specified destination.
 


### PR DESCRIPTION
## Proposed Changes

Always return the envelope when received as a response to an outgoing sync message. Previously we processed these via the dispatcher if it was there, but this kind of defeats the purpose of sending a message synchronously as it cannot be handled within the same handler from which it was sent.

Also added a default timeout for sync responses.

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
