### PR TITLE
Fix: Add port and endpoint to "19-rest-api" example

### DIFF
--- a/python/examples/19-rest-api/agent.py
+++ b/python/examples/19-rest-api/agent.py
@@ -19,7 +19,7 @@ class EmptyMessage(Model):
     pass
 
 
-agent = Agent(name="Rest API")
+agent = Agent(name="Rest API", seed="your_seed_phrase", port=8000, endpoint=["http://localhost:8000/submit"])
 
 
 @agent.on_rest_get("/rest/get", Response)


### PR DESCRIPTION
The "19-rest-api" example currently initializes the agent without defining the port and endpoint. This might cause confusion for users trying to follow the example, as these are essential parameters for the agent to work correctly in a REST API setup.