### PR TITLE
chore(core): use agent identifier in almanac attestation

### DIFF
--- a/python/examples/04-storage/main.py
+++ b/python/examples/04-storage/main.py
@@ -1,6 +1,6 @@
 from uagents import Agent, Context
 
-agent = Agent(name="bob", endpoint="test", agentverse="http://localhost:8001")
+agent = Agent(name="bob")
 
 
 @agent.on_event("startup")

--- a/python/examples/04-storage/main.py
+++ b/python/examples/04-storage/main.py
@@ -1,6 +1,6 @@
 from uagents import Agent, Context
 
-agent = Agent(name="bob")
+agent = Agent(name="bob", endpoint="test", agentverse="http://localhost:8001")
 
 
 @agent.on_event("startup")

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -423,7 +423,7 @@ class Agent(Sink):
             @self.on_rest_get("/agent_info", AgentInfo)  # type: ignore
             async def _handle_get_info(_ctx: Context):
                 return AgentInfo(
-                    agent_address=self.address,
+                    identifier=self.identifier,
                     endpoints=self._endpoints,
                     protocols=list(self.protocols.keys()),
                 )
@@ -672,7 +672,7 @@ class Agent(Sink):
             AgentInfo: The agent's address, endpoints, protocols, and metadata.
         """
         return AgentInfo(
-            agent_address=self.address,
+            identifier=self.identifier,
             endpoints=self._endpoints,
             protocols=list(self.protocols.keys()),
             metadata=self.metadata,
@@ -804,7 +804,10 @@ class Agent(Sink):
         assert self._registration_policy is not None, "Agent has no registration policy"
 
         await self._registration_policy.register(
-            self.address, list(self.protocols.keys()), self._endpoints, self._metadata
+            self.identifier,
+            list(self.protocols.keys()),
+            self._endpoints,
+            self._metadata,
         )
 
     async def _schedule_registration(self):
@@ -1123,7 +1126,9 @@ class Agent(Sink):
 
         """
         try:
-            status = AgentStatusUpdate(agent_address=self.address, is_active=False)
+            status = AgentStatusUpdate(
+                agent_identifier=self.identifier, is_active=False
+            )
             status.sign(self._identity)
             await update_agent_status(status, self._almanac_api_url)
         except Exception as ex:

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -446,7 +446,7 @@ class AlmanacContract(LedgerContract):
                 endpoints=record.endpoints,
                 signature=record.signature,
                 sequence=record.timestamp,
-                address=record.agent_address,
+                address=record.identifier,
             )
 
             denom = self._client.network_config.fee_denomination

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -10,7 +10,7 @@ import aiohttp
 from cosmpy.aerial.client import LedgerClient
 from cosmpy.aerial.wallet import LocalWallet
 from cosmpy.crypto.address import Address
-from pydantic import BaseModel
+from pydantic import AliasChoices, BaseModel, Field
 
 from uagents.config import (
     ALMANAC_API_MAX_RETRIES,
@@ -33,7 +33,9 @@ from uagents.types import AgentEndpoint, AgentInfo
 
 
 class VerifiableModel(BaseModel):
-    agent_identifier: str
+    agent_identifier: str = Field(
+        validation_alias=AliasChoices("agent_identifier", "agent_address")
+    )
     signature: Optional[str] = None
     timestamp: Optional[int] = None
 

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -28,11 +28,12 @@ from uagents.network import (
     InsufficientFundsError,
     add_testnet_funds,
 )
+from uagents.resolver import parse_identifier
 from uagents.types import AgentEndpoint, AgentInfo
 
 
 class VerifiableModel(BaseModel):
-    agent_address: str
+    agent_identifier: str
     signature: Optional[str] = None
     timestamp: Optional[int] = None
 
@@ -42,8 +43,9 @@ class VerifiableModel(BaseModel):
         self.signature = identity.sign_digest(digest)
 
     def verify(self) -> bool:
+        _, _, agent_address = parse_identifier(self.agent_identifier)
         return self.signature is not None and Identity.verify_digest(
-            self.agent_address, self._build_digest(), self.signature
+            agent_address, self._build_digest(), self.signature
         )
 
     def _build_digest(self) -> bytes:
@@ -172,14 +174,14 @@ class AlmanacApiRegistrationPolicy(AgentRegistrationPolicy):
 
     async def register(
         self,
-        agent_address: str,
+        agent_identifier: str,
         protocols: List[str],
         endpoints: List[AgentEndpoint],
         metadata: Optional[Dict[str, Any]] = None,
     ):
         # create the attestation
         attestation = AgentRegistrationAttestation(
-            agent_address=agent_address,
+            agent_identifier=agent_identifier,
             protocols=protocols,
             endpoints=endpoints,
             metadata=coerce_metadata_to_str(extract_geo_metadata(metadata)),
@@ -207,7 +209,7 @@ class BatchAlmanacApiRegistrationPolicy(AgentRegistrationPolicy):
 
     def add_agent(self, agent_info: AgentInfo, identity: Identity):
         attestation = AgentRegistrationAttestation(
-            agent_address=agent_info.agent_address,
+            agent_identifier=agent_info.identifier,
             protocols=list(agent_info.protocols),
             endpoints=agent_info.endpoints,
             metadata=coerce_metadata_to_str(extract_geo_metadata(agent_info.metadata)),
@@ -264,7 +266,7 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
 
     async def register(
         self,
-        agent_address: str,
+        agent_identifier: str,
         protocols: List[str],
         endpoints: List[AgentEndpoint],
         metadata: Optional[Dict[str, Any]] = None,
@@ -274,6 +276,8 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
         the registration data has changed.
         """
         self.check_contract_version()
+
+        _, _, agent_address = parse_identifier(agent_identifier)
 
         if (
             not self._almanac_contract.is_registered(agent_address)
@@ -359,14 +363,14 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
 
     def add_agent(self, agent_info: AgentInfo, identity: Identity):
         agent_record = AlmanacContractRecord(
-            agent_address=agent_info.agent_address,
+            identifier=agent_info.identifier,
             protocols=agent_info.protocols,
             endpoints=agent_info.endpoints,
             contract_address=str(self._almanac_contract.address),
             sender_address=str(self._wallet.address()),
         )
         self._records.append(agent_record)
-        self._identities[agent_info.agent_address] = identity
+        self._identities[agent_info.identifier] = identity
 
     def _get_balance(self) -> int:
         return self._ledger.query_bank_balance(Address(self._wallet.address()))
@@ -374,7 +378,8 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
     async def register(self):
         self._logger.info("Registering agents on Almanac contract...")
         for record in self._records:
-            record.sign(self._identities[record.agent_address])
+            _, _, agent_address = parse_identifier(record.identifier)
+            record.sign(self._identities[agent_address])
 
         if self._get_balance() < REGISTRATION_FEE * len(self._records):
             self._logger.warning(
@@ -456,8 +461,9 @@ class DefaultRegistrationPolicy(AgentRegistrationPolicy):
 
 
 async def update_agent_status(status: AgentStatusUpdate, almanac_api: str):
+    _, _, agent_address = parse_identifier(status.agent_identifier)
     await almanac_api_post(
-        f"{almanac_api}/agents/{status.agent_address}/status",
+        f"{almanac_api}/agents/{agent_address}/status",
         status,
         raise_from=False,
     )

--- a/python/src/uagents/types.py
+++ b/python/src/uagents/types.py
@@ -44,7 +44,7 @@ class AgentEndpoint(BaseModel):
 
 
 class AgentInfo(BaseModel):
-    agent_address: str
+    identifier: str
     endpoints: List[AgentEndpoint]
     protocols: List[str]
     metadata: Optional[Dict[str, Any]] = None

--- a/python/tests/test_registration.py
+++ b/python/tests/test_registration.py
@@ -24,7 +24,7 @@ def test_attestation_signature():
 
     # create a dummy attestation
     attestation = AgentRegistrationAttestation(
-        agent_address=identity.address,
+        agent_identifier=identity.address,
         protocols=TEST_PROTOCOLS,
         endpoints=TEST_ENDPOINTS,
     )
@@ -42,7 +42,7 @@ def test_attestation_signature_with_metadata():
 
     # create a dummy attestation
     attestation = AgentRegistrationAttestation(
-        agent_address=identity.address,
+        agent_identifier=identity.address,
         protocols=TEST_PROTOCOLS,
         endpoints=TEST_ENDPOINTS,
         metadata=coerce_metadata_to_str(
@@ -63,7 +63,7 @@ def test_recovery_of_attestation():
 
     # create an attestation
     original_attestation = AgentRegistrationAttestation(
-        agent_address=identity.address,
+        agent_identifier=identity.address,
         protocols=TEST_PROTOCOLS,
         endpoints=TEST_ENDPOINTS,
     )
@@ -71,7 +71,7 @@ def test_recovery_of_attestation():
 
     # recover the attestation
     recovered = AgentRegistrationAttestation(
-        agent_address=original_attestation.agent_address,
+        agent_identifier=original_attestation.agent_identifier,
         protocols=TEST_PROTOCOLS,
         endpoints=TEST_ENDPOINTS,
         signature=original_attestation.signature,
@@ -96,7 +96,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         mocked_responses.post(f"{self.MOCKED_ALMANAC_API}/agents", status=200)
 
         await self.policy.register(
-            agent_address=self.identity.address,
+            agent_identifier=self.identity.address,
             protocols=TEST_PROTOCOLS,
             endpoints=TEST_ENDPOINTS,
         )
@@ -108,7 +108,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
 
         with pytest.raises(ClientResponseError):
             await self.policy.register(
-                agent_address=self.identity.address,
+                agent_identifier=self.identity.address,
                 protocols=TEST_PROTOCOLS,
                 endpoints=TEST_ENDPOINTS,
             )
@@ -120,7 +120,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
 
         with pytest.raises(ClientResponseError):
             await self.policy.register(
-                agent_address=self.identity.address,
+                agent_identifier=self.identity.address,
                 protocols=TEST_PROTOCOLS,
                 endpoints=TEST_ENDPOINTS,
             )


### PR DESCRIPTION
## Proposed Changes

In order to for the Almanac API to know whether an agent is registered on testnet or mainnet, it need to have access to the full prefixed agent identifier (`test-agent://agent1...`, `agent://agent1...`), not just the agent address.

## Linked Issues

https://github.com/fetchai/uAgents/issues/520

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)