### PR TITLE
feat(core): send address prefix to mailbox API

### DIFF
--- a/python/docs/api/uagents/mailbox.md
+++ b/python/docs/api/uagents/mailbox.md
@@ -40,6 +40,7 @@ Check if the agent is a proxy agent.
 async def register_in_agentverse(
         request: AgentverseConnectRequest,
         identity: Identity,
+        prefix: AddressPrefix,
         endpoints: list[AgentEndpoint],
         agentverse: AgentverseConfig,
         agent_details: Optional[AgentUpdates] = None) -> RegistrationResponse
@@ -51,6 +52,7 @@ Registers agent in Agentverse
 
 - `request` _AgentverseConnectRequest_ - Request object
 - `identity` _Identity_ - Agent identity object
+- `prefix` _AddressPrefix_ - Agent address prefix - can be "agent" (mainnet) or "test-agent" (testnet) 
 - `endpoints` _list[AgentEndpoint]_ - Endpoints of the agent
 - `agentverse` _AgentverseConfig_ - Agentverse configuration
   

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -448,6 +448,7 @@ class Agent(Sink):
                 return await register_in_agentverse(
                     request,
                     self._identity,
+                    TESTNET_PREFIX if self._test else MAINNET_PREFIX,
                     self._agentverse,
                     agent_details,
                 )

--- a/python/src/uagents/mailbox.py
+++ b/python/src/uagents/mailbox.py
@@ -46,8 +46,12 @@ class ChallengeProofResponse(Model):
     expiry: str
 
 
+AddressPrefix = Literal["agent", "test-agent"]
+
+
 class RegistrationRequest(BaseModel):
     address: str
+    prefix: AddressPrefix
     challenge: str
     challenge_response: str
     agent_type: AgentType
@@ -87,6 +91,7 @@ def is_mailbox_agent(
 async def register_in_agentverse(
     request: AgentverseConnectRequest,
     identity: Identity,
+    prefix: AddressPrefix,
     agentverse: AgentverseConfig,
     agent_details: Optional[AgentUpdates] = None,
 ) -> RegistrationResponse:
@@ -96,6 +101,8 @@ async def register_in_agentverse(
     Args:
         request (AgentverseConnectRequest): Request object
         identity (Identity): Agent identity object
+        prefix (AddressPrefix): Agent address prefix
+            can be "agent" (mainnet) or "test-agent" (testnet)
         agentverse (AgentverseConfig): Agentverse configuration
         agent_details (Optional[AgentUpdates]): Agent details (name, readme, avatar_url)
 
@@ -124,6 +131,7 @@ async def register_in_agentverse(
             prove_url,
             data=RegistrationRequest(
                 address=identity.address,
+                prefix=prefix,
                 challenge=challenge.challenge,
                 challenge_response=identity.sign(challenge.challenge.encode()),
                 endpoint=request.endpoint,


### PR DESCRIPTION
## Proposed Changes

In Agentverse we want to show the address prefix ("agent" in case of mainnet agent, "test-agent" in case of testnet agent) prepended to the address everywhere where agents are listed/shown (for example `agant://agent1qgd5jllcnav0u5dylemttag2cnmdewlpyhsjvy9z03kdr7xwyycyucfjf69` instead of `agent1qgd5jllcnav0u5dylemttag2cnmdewlpyhsjvy9z03kdr7xwyycyucfjf69`). For this the prefix needs to be sent to the mailbox API when a mailbox agent is created. This PR makes it possible to send the prefix.

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [ ] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
