### PR TITLE
feat(core): make agent address prefix optional in mailbox RegistrationRequest

### DIFF
--- a/python/src/uagents/mailbox.py
+++ b/python/src/uagents/mailbox.py
@@ -51,7 +51,7 @@ AddressPrefix = Literal["agent", "test-agent"]
 
 class RegistrationRequest(BaseModel):
     address: str
-    prefix: AddressPrefix
+    prefix: Optional[AddressPrefix] = "test-agent"
     challenge: str
     challenge_response: str
     agent_type: AgentType


### PR DESCRIPTION
## Proposed Changes

Make `prefix` attribute optional so that mailbox API will be backwards compatible with older/current uagents version

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [ ] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
