### PR TITLE
refactor(core): separate prefix from address in agent info

### DIFF
--- a/python/docs/api/uagents/mailbox.md
+++ b/python/docs/api/uagents/mailbox.md
@@ -17,21 +17,6 @@ Check if the agent is a mailbox agent.
 
 - `bool` - True if the agent is a mailbox agent, False otherwise.
 
-<a id="src.uagents.mailbox.is_proxy_agent"></a>
-
-#### is`_`proxy`_`agent
-
-```python
-def is_proxy_agent(endpoints: list[AgentEndpoint],
-                   agentverse: AgentverseConfig) -> bool
-```
-
-Check if the agent is a proxy agent.
-
-**Returns**:
-
-- `bool` - True if the agent is a proxy agent, False otherwise.
-
 <a id="src.uagents.mailbox.register_in_agentverse"></a>
 
 #### register`_`in`_`agentverse
@@ -41,7 +26,6 @@ async def register_in_agentverse(
         request: AgentverseConnectRequest,
         identity: Identity,
         prefix: AddressPrefix,
-        endpoints: list[AgentEndpoint],
         agentverse: AgentverseConfig,
         agent_details: Optional[AgentUpdates] = None) -> RegistrationResponse
 ```
@@ -52,9 +36,10 @@ Registers agent in Agentverse
 
 - `request` _AgentverseConnectRequest_ - Request object
 - `identity` _Identity_ - Agent identity object
-- `prefix` _AddressPrefix_ - Agent address prefix - can be "agent" (mainnet) or "test-agent" (testnet) 
-- `endpoints` _list[AgentEndpoint]_ - Endpoints of the agent
+- `prefix` _AddressPrefix_ - Agent address prefix
+  can be "agent" (mainnet) or "test-agent" (testnet)
 - `agentverse` _AgentverseConfig_ - Agentverse configuration
+- `agent_details` _Optional[AgentUpdates]_ - Agent details (name, readme, avatar_url)
   
 
 **Returns**:

--- a/python/docs/api/uagents/registration.md
+++ b/python/docs/api/uagents/registration.md
@@ -59,7 +59,8 @@ if it is different from the supported version.
 #### register
 
 ```python
-async def register(agent_address: str,
+async def register(agent_identifier: str,
+                   identity: Identity,
                    protocols: List[str],
                    endpoints: List[AgentEndpoint],
                    metadata: Optional[Dict[str, Any]] = None)

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -422,7 +422,8 @@ class Agent(Sink):
             @self.on_rest_get("/agent_info", AgentInfo)  # type: ignore
             async def _handle_get_info(_ctx: Context):
                 return AgentInfo(
-                    identifier=self.identifier,
+                    address=self.address,
+                    prefix=TESTNET_PREFIX if self._test else MAINNET_PREFIX,
                     endpoints=self._endpoints,
                     protocols=list(self.protocols.keys()),
                 )
@@ -672,7 +673,8 @@ class Agent(Sink):
             AgentInfo: The agent's address, endpoints, protocols, and metadata.
         """
         return AgentInfo(
-            identifier=self.identifier,
+            address=self.address,
+            prefix=TESTNET_PREFIX if self._test else MAINNET_PREFIX,
             endpoints=self._endpoints,
             protocols=list(self.protocols.keys()),
             metadata=self.metadata,

--- a/python/src/uagents/mailbox.py
+++ b/python/src/uagents/mailbox.py
@@ -12,7 +12,7 @@ from uagents.crypto import Identity, is_user_address
 from uagents.dispatch import dispatcher
 from uagents.envelope import Envelope
 from uagents.models import Model
-from uagents.types import AgentEndpoint
+from uagents.types import AddressPrefix, AgentEndpoint
 from uagents.utils import get_logger
 
 logger = get_logger("mailbox")
@@ -44,9 +44,6 @@ class ChallengeProof(BaseModel):
 class ChallengeProofResponse(Model):
     access_token: str
     expiry: str
-
-
-AddressPrefix = Literal["agent", "test-agent"]
 
 
 class RegistrationRequest(BaseModel):

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -446,7 +446,7 @@ class AlmanacContract(LedgerContract):
                 endpoints=record.endpoints,
                 signature=record.signature,
                 sequence=record.timestamp,
-                address=record.identifier,
+                address=record.address,
             )
 
             denom = self._client.network_config.fee_denomination

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -378,8 +378,7 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
     async def register(self):
         self._logger.info("Registering agents on Almanac contract...")
         for record in self._records:
-            _, _, agent_address = parse_identifier(record.address)
-            record.sign(self._identities[agent_address])
+            record.sign(self._identities[record.address])
 
         if self._get_balance() < REGISTRATION_FEE * len(self._records):
             self._logger.warning(

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -209,7 +209,7 @@ class BatchAlmanacApiRegistrationPolicy(BatchRegistrationPolicy):
 
     def add_agent(self, agent_info: AgentInfo, identity: Identity):
         attestation = AgentRegistrationAttestation(
-            agent_identifier=agent_info.identifier,
+            agent_identifier=f"{agent_info.prefix}://{agent_info.address}",
             protocols=list(agent_info.protocols),
             endpoints=agent_info.endpoints,
             metadata=coerce_metadata_to_str(extract_geo_metadata(agent_info.metadata)),
@@ -362,14 +362,15 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
 
     def add_agent(self, agent_info: AgentInfo, identity: Identity):
         agent_record = AlmanacContractRecord(
-            identifier=agent_info.identifier,
+            address=agent_info.address,
+            prefix=agent_info.prefix,
             protocols=agent_info.protocols,
             endpoints=agent_info.endpoints,
             contract_address=str(self._almanac_contract.address),
             sender_address=str(self._wallet.address()),
         )
         self._records.append(agent_record)
-        self._identities[agent_info.identifier] = identity
+        self._identities[agent_info.address] = identity
 
     def _get_balance(self) -> int:
         return self._ledger.query_bank_balance(Address(self._wallet.address()))
@@ -377,7 +378,7 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
     async def register(self):
         self._logger.info("Registering agents on Almanac contract...")
         for record in self._records:
-            _, _, agent_address = parse_identifier(record.identifier)
+            _, _, agent_address = parse_identifier(record.address)
             record.sign(self._identities[agent_address])
 
         if self._get_balance() < REGISTRATION_FEE * len(self._records):

--- a/python/src/uagents/types.py
+++ b/python/src/uagents/types.py
@@ -38,13 +38,17 @@ RestMethod = Literal["GET", "POST"]
 RestHandlerMap = Dict[Tuple[RestMethod, str], RestHandler]
 
 
+AddressPrefix = Literal["agent", "test-agent"]
+
+
 class AgentEndpoint(BaseModel):
     url: str
     weight: int
 
 
 class AgentInfo(BaseModel):
-    identifier: str
+    address: str
+    prefix: AddressPrefix
     endpoints: List[AgentEndpoint]
     protocols: List[str]
     metadata: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Proposed Changes

Changing the field `address` to `identifier` in `AgentInfo` breaks the local agent inspector, so since this is not actually needed for the updated almanac attestation, let's simply add prefix as a new field to the `AgentInfo` model instead.

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
