### PR TITLE
feat(core): allow general access to rest endpoints, except inspector ones

### DIFF
--- a/python/src/uagents/asgi.py
+++ b/python/src/uagents/asgi.py
@@ -310,7 +310,10 @@ class ASGIServer:
         # check if the request is for a REST endpoint
         handlers = self._get_rest_handler_details(request_method, request_path)
         if handlers:
-            if "127.0.0.1" not in scope["client"]:
+            if (
+                request_path in RESERVED_ENDPOINTS
+                and "127.0.0.1" not in scope["client"]
+            ):
                 await self._asgi_send(send, 403, body={"error": "forbidden"})
                 return
             await self._handle_rest(headers, handlers, send, receive)

--- a/python/tests/test_rest.py
+++ b/python/tests/test_rest.py
@@ -250,11 +250,7 @@ async def test_rest_post_fail_invalid_response():
 
 
 @pytest.mark.order(6)
-async def test_rest_wrong_client():
-    @agent.on_rest_get("/get-wrong-client", Response)
-    async def _(_ctx: Context):
-        return Response(text="Hi there!")
-
+async def test_inspector_rest_wrong_client():
     mock_send = AsyncMock()
     with patch("uagents.asgi._read_asgi_body") as mock_receive:
         mock_receive.return_value = b""
@@ -262,7 +258,7 @@ async def test_rest_wrong_client():
             scope={
                 "type": "http",
                 "method": "GET",
-                "path": "/get-wrong-client",
+                "path": "/agent_info",
                 "client": ("agentverse.ai",),
             },
             receive=None,


### PR DESCRIPTION
This PR makes all agent REST endpoints available to any caller, except those used for the inspector which will still be restricted to localhost only.