### PR TITLE
fix(core): include internal protocol on agent init

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -404,11 +404,12 @@ class Agent(Sink):
 
         self.initialize_wallet_messaging(enable_wallet_messaging)
 
-        # initialize the internal agent protocol
-        self._protocol = Protocol(name=self._name, version=self._version)
-
         # keep track of supported protocols
         self.protocols: Dict[str, Protocol] = {}
+
+        # initialize the internal agent protocol
+        self._protocol = Protocol(name=self._name, version=self._version)
+        self.include(self._protocol)
 
         # register with the dispatcher
         self._dispatcher.register(self.address, self)
@@ -1162,9 +1163,8 @@ class Agent(Sink):
 
     async def setup(self):
         """
-        Include the internal agent protocol, run startup tasks, and start background tasks.
+        Run startup tasks and start background tasks.
         """
-        self.include(self._protocol)
         self.start_message_dispenser()
         await self._startup()
         self.start_message_receivers()

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -409,7 +409,6 @@ class Agent(Sink):
 
         # initialize the internal agent protocol
         self._protocol = Protocol(name=self._name, version=self._version)
-        self.include(self._protocol)
 
         # register with the dispatcher
         self._dispatcher.register(self.address, self)
@@ -1163,8 +1162,9 @@ class Agent(Sink):
 
     async def setup(self):
         """
-        Run startup tasks and start background tasks.
+        Include the internal agent protocol, run startup tasks, and start background tasks.
         """
+        self.include(self._protocol)
         self.start_message_dispenser()
         await self._startup()
         self.start_message_receivers()
@@ -1535,7 +1535,6 @@ class Bureau:
         if agent in self._agents:
             return
         self._update_agent(agent)
-        self._registration_policy.add_agent(agent.info, agent._identity)
         self._agents.append(agent)
 
     async def _schedule_registration(self):
@@ -1569,6 +1568,7 @@ class Bureau:
             return
         for agent in self._agents:
             await agent.setup()
+            self._registration_policy.add_agent(agent.info, agent._identity)
             if (
                 is_mailbox_agent(agent._endpoints, self._agentverse)
                 and agent.mailbox_client is not None


### PR DESCRIPTION
Including the internal protocol on agent initialization ensures that it will be set in `agent.info` when the agent is added to a BatchRegistrationPolicy. Previously, it was included on `agent.setup()` which only gets executed after the RegistrationPolicy has been prepared, thus bureau agents have never included their internal protocol in registration until now (leading to errors in the Almanac API in certain cases).