### PR TITLE
feat(core): add send and receive function

### DIFF
--- a/python/examples/20-send-and-receive/main.py
+++ b/python/examples/20-send-and-receive/main.py
@@ -1,0 +1,46 @@
+from uagents import Agent, Bureau, Context, Model
+
+
+class Message(Model):
+    message: str
+
+
+alice = Agent(name="alice")
+bob = Agent(name="bob")
+clyde = Agent(name="clyde")
+
+
+@alice.on_interval(period=5.0)
+async def send_message(ctx: Context):
+    msg = Message(message="Hey Bob, how's Clyde?")
+    reply, status = await ctx.send_and_receive(bob.address, msg, response_type=Message)
+    if isinstance(reply, Message):
+        ctx.logger.info(f"Received awaited response from bob: {reply.message}")
+    else:
+        ctx.logger.info(f"Failed to receive response from bob: {status}")
+
+
+@bob.on_message(model=Message)
+async def handle_message_and_reply(ctx: Context, sender: str, msg: Message):
+    ctx.logger.info(f"Received message: {msg.message}")
+    new_msg = Message(message="How are you, Clyde?")
+    reply, status = await ctx.send_and_receive(
+        clyde.address, new_msg, response_type=Message
+    )
+    if isinstance(reply, Message):
+        ctx.logger.info(f"Received awaited response from clyde: {reply.message}")
+        await ctx.send(sender, Message(message="Clyde is doing alright!"))
+    else:
+        ctx.logger.info(f"Failed to receive response from clyde: {status}")
+
+
+@clyde.on_message(model=Message)
+async def handle_message(ctx: Context, sender: str, msg: Message):
+    ctx.logger.info(f"Received message from {sender}: {msg.message}")
+    await ctx.send(sender, Message(message="I'm doing alright!"))
+
+
+bureau = Bureau([alice, bob, clyde])
+
+if __name__ == "__main__":
+    bureau.run()

--- a/python/src/uagents/dispatch.py
+++ b/python/src/uagents/dispatch.py
@@ -1,9 +1,13 @@
+import asyncio
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Set, Union
+from asyncio import Future
+from typing import Any, Dict, Optional, Set, Tuple, Union
 
 from uagents.models import Model
 from uagents.types import JsonStr, RestMethod
+
+AsyncResponseKey = Tuple[str, str, uuid.UUID]
 
 
 class Sink(ABC):
@@ -31,10 +35,39 @@ class Dispatcher:
 
     def __init__(self):
         self._sinks: Dict[str, Set[Sink]] = {}
+        self._pending_responses: Dict[AsyncResponseKey, Future[JsonStr]] = {}
 
     @property
     def sinks(self) -> Dict[str, Set[Sink]]:
         return self._sinks
+
+    @property
+    def pending_responses(self) -> Dict[AsyncResponseKey, Future[JsonStr]]:
+        return self._pending_responses
+
+    def register_pending_response(
+        self, sender: str, destination: str, session: uuid.UUID
+    ):
+        self._pending_responses[(sender, destination, session)] = (
+            asyncio.get_event_loop().create_future()
+        )
+
+    async def get_pending_response(
+        self, sender: str, destination: str, session: uuid.UUID, timeout: float
+    ) -> JsonStr:
+        key = (sender, destination, session)
+        response = await asyncio.wait_for(self._pending_responses[key], timeout)
+        del self._pending_responses[key]
+        return response
+
+    def dispatch_pending_response(
+        self, sender: str, destination: str, session: uuid.UUID, message: JsonStr
+    ) -> bool:
+        key = (destination, sender, session)
+        if key in self._pending_responses:
+            self._pending_responses[key].set_result(message)
+            return True
+        return False
 
     def register(self, address: str, sink: Sink):
         destinations = self._sinks.get(address, set())
@@ -60,6 +93,8 @@ class Dispatcher:
         message: JsonStr,
         session: uuid.UUID,
     ) -> None:
+        if self.dispatch_pending_response(sender, destination, session, message):
+            return
         for handler in self._sinks.get(destination, set()):
             await handler.handle_message(sender, schema_digest, message, session)
 

--- a/python/src/uagents/dispatch.py
+++ b/python/src/uagents/dispatch.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional, Set, Tuple, Union
 from uagents.models import Model
 from uagents.types import JsonStr, RestMethod
 
-AsyncResponseKey = Tuple[str, str, uuid.UUID]
+PendingResponseKey = Tuple[str, str, uuid.UUID]
 
 
 class Sink(ABC):
@@ -35,14 +35,14 @@ class Dispatcher:
 
     def __init__(self):
         self._sinks: Dict[str, Set[Sink]] = {}
-        self._pending_responses: Dict[AsyncResponseKey, Future[JsonStr]] = {}
+        self._pending_responses: Dict[PendingResponseKey, Future[JsonStr]] = {}
 
     @property
     def sinks(self) -> Dict[str, Set[Sink]]:
         return self._sinks
 
     @property
-    def pending_responses(self) -> Dict[AsyncResponseKey, Future[JsonStr]]:
+    def pending_responses(self) -> Dict[PendingResponseKey, Future[JsonStr]]:
         return self._pending_responses
 
     def register_pending_response(

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -147,27 +147,6 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, exp_msg_status)
 
-    async def test_send_resolve_sync_query(self):
-        future = asyncio.Future()
-        context = self.get_external_context(
-            incoming,
-            incoming_digest,
-            replies=test_replies,
-            queries={self.clyde.address: future},
-        )
-        result = await context.send(self.clyde.address, msg, sync=True)
-        exp_msg_status = MsgStatus(
-            status=DeliveryStatus.DELIVERED,
-            detail="Sync message resolved",
-            destination=self.clyde.address,
-            endpoint="",
-            session=context.session,
-        )
-
-        self.assertEqual(future.result(), (msg.model_dump_json(), msg_digest))
-        self.assertEqual(result, exp_msg_status)
-        self.assertEqual(len(context._queries), 0, "Query not removed from context")
-
     async def test_send_external_dispatch_resolve_failure(self):
         destination = Identity.generate().address
         context = self.alice._build_context()


### PR DESCRIPTION
## Proposed Changes

Add new function to send and wait for response to a message. In this case, the sender must specify the response type, and can also specify a timeout. Works for both async and sync messaging.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
