### PR TITLE
feat(core): enable session history storage in protocol

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -1065,6 +1065,9 @@ class Agent(Sink):
         if publish_manifest:
             self.publish_manifest(protocol.manifest())
 
+        if protocol.use_storage:
+            protocol.storage = self._storage
+
     def publish_manifest(self, manifest: Dict[str, Any]):
         """
         Publish a protocol manifest to the Almanac service.
@@ -1361,6 +1364,9 @@ class Agent(Sink):
                     ),
                 )
                 continue
+
+            if protocol_info and protocol_info[1].store_message_history:
+                pass
 
             # attempt to find the handler
             handler: Optional[MessageCallback] = self._unsigned_message_handlers.get(

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -1310,7 +1310,8 @@ class Agent(Sink):
                 continue
 
             protocol_info = self.get_message_protocol(schema_digest)
-            protocol_digest = protocol_info[0] if protocol_info else None
+            if protocol_info:
+                protocol_digest, protocol = protocol_info
 
             if self._message_cache:
                 self._message_cache.add_entry(
@@ -1365,8 +1366,10 @@ class Agent(Sink):
                 )
                 continue
 
-            if protocol_info and protocol_info[1].store_message_history:
-                pass
+            if protocol_info and protocol.store_message_history:
+                protocol.store_message(
+                    session, schema_digest, sender, self.address, message
+                )
 
             # attempt to find the handler
             handler: Optional[MessageCallback] = self._unsigned_message_handlers.get(

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -548,8 +548,8 @@ class InternalContext(Context):
                 session=self._session,
             )
 
-        if self._protocol[1] is not None and self._protocol[1].store_message_history:
-            self._protocol[1].store_message(
+        if self.protocol is not None and self.protocol.store_message_history:
+            self.protocol.store_message(
                 self._session,
                 message_schema_digest,
                 self.agent.address,

--- a/python/src/uagents/protocol.py
+++ b/python/src/uagents/protocol.py
@@ -335,7 +335,17 @@ class Protocol:
         content: JsonStr,
         **kwargs,
     ) -> None:
-        """Add a message to the conversation of the given session within the dialogue instance."""
+        """
+        Add a message to the conversation of the given session.
+
+        Args:
+            session_id (UUID4): The ID of the session to store the message for.
+            schema_digest (str): The schema digest of the message.
+            sender (str): The sender of the message.
+            receiver (str): The receiver of the message.
+            content (JsonStr): The content of the message.
+            **kwargs: Additional message metadata.
+        """
         if self.storage is None:
             raise ValueError("Storage must be set before storing messages!")
         if session_id is None:
@@ -355,7 +365,7 @@ class Protocol:
         )
         self.storage.set(storage_key, session_history)
 
-    def get_conversation(self, session_id: UUID4) -> List[Any]:
+    def get_conversation(self, session_id: UUID4) -> List[Dict[str, Any]]:
         """
         Return the message history for the given session.
 
@@ -363,7 +373,7 @@ class Protocol:
             session_id (UUID4): The ID of the session to get the conversation for.
 
         Returns:
-
+            List[Dict[str, Any]]: The list of messages in the conversation
         """
         if self._storage is None:
             raise ValueError("Protocol does not have storage set!")

--- a/python/src/uagents/protocol.py
+++ b/python/src/uagents/protocol.py
@@ -190,6 +190,7 @@ class Protocol:
         Args:
             storage (StorageAPI): The storage reference to set.
         """
+        self._storage = storage
 
     def on_interval(
         self,
@@ -328,7 +329,6 @@ class Protocol:
     def store_message(
         self,
         session_id: UUID4,
-        message_type: str,
         schema_digest: str,
         sender: str,
         receiver: str,
@@ -345,7 +345,6 @@ class Protocol:
         session_history = self.storage.get(storage_key) or []
         session_history.append(
             {
-                "message_type": message_type,
                 "schema_digest": schema_digest,
                 "sender": sender,
                 "receiver": receiver,
@@ -354,6 +353,22 @@ class Protocol:
                 **kwargs,
             }
         )
+        self.storage.set(storage_key, session_history)
+
+    def get_conversation(self, session_id: UUID4) -> List[Any]:
+        """
+        Return the message history for the given session.
+
+        Args:
+            session_id (UUID4): The ID of the session to get the conversation for.
+
+        Returns:
+
+        """
+        if self._storage is None:
+            raise ValueError("Protocol does not have storage set!")
+        storage_key = f"{self.name}:{session_id}"
+        return self._storage.get(storage_key) or []
 
     def manifest(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Proposed Changes

Allow protocols to use agent storage to store the message history by session id.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
