### PR TITLE
fix(core): response not assigned error

### DIFF
--- a/python/uagents-core/uagents_core/utils/messages.py
+++ b/python/uagents-core/uagents_core/utils/messages.py
@@ -144,7 +144,7 @@ def send_message_to_agent(
             result.append(
                 MsgStatus(
                     status=DeliveryStatus.FAILED,
-                    detail=response.text,
+                    detail=str(e),
                     destination=destination,
                     endpoint=endpoint,
                     session=env.session,


### PR DESCRIPTION
## Proposed Changes

Fixes a bug in the `send_message_to_agent()` method in `uagents_core.utils.messages` where if an exception was raised a variable was accessed that has not been assigned at that point.

```python
Failed to send message to agent: cannot access local variable 'response' where it is not associated with a value
```

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
