### PR TITLE
fix(core): reply validation

### DIFF
--- a/python/docs/api/uagents/context.md
+++ b/python/docs/api/uagents/context.md
@@ -314,14 +314,14 @@ Get the session UUID associated with the context.
 #### outbound_messages[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L321)
 ```python
 @property
-def outbound_messages() -> dict[str, tuple[JsonStr, str]]
+def outbound_messages() -> dict[str, list[tuple[JsonStr, str]]]
 ```
 
 Get the dictionary of outbound messages associated with the context.
 
 **Returns**:
 
-  dict[str, tuple[JsonStr, str]]: The dictionary of outbound messages.
+  dict[str, list[tuple[JsonStr, str]]]: The dictionary of outbound messages.
 
 
 
@@ -352,7 +352,7 @@ contexts, like 'replies', 'message_received', or 'protocol'.
 
 
 
-#### send_and_receive[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L589)
+#### send_and_receive[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L593)
 ```python
 async def send_and_receive(
     destination: str,
@@ -380,7 +380,7 @@ Send a message to the specified destination and receive a response.
 
 
 
-## ExternalContext Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L689)
+## ExternalContext Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L693)
 
 ```python
 class ExternalContext(InternalContext)
@@ -400,7 +400,7 @@ Represents the reactive context in which messages are handled and processed.
 
 
 
-#### __init__[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L703)
+#### __init__[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L707)
 ```python
 def __init__(message_received: MsgInfo,
              queries: dict[str, asyncio.Future] | None = None,
@@ -422,16 +422,20 @@ Initialize the ExternalContext instance and attributes needed from the InternalC
 
 
 
-#### validate_replies[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L728)
+#### validate_replies[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L732)
 ```python
-def validate_replies() -> None
+def validate_replies(message_type: type[Model]) -> None
 ```
 
 If the context specifies replies, ensure that a valid reply was sent.
 
+**Arguments**:
+
+- `message_type` _type[Model]_ - The type of the received message.
 
 
-#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L753)
+
+#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L773)
 ```python
 async def send(destination: str,
                message: Model,

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -1321,7 +1321,7 @@ class Agent(Sink):
             if handler is not None:
                 try:
                     await handler(context, sender, recovered)
-                    context.validate_replies()
+                    context.validate_replies(model_class)
                 except OSError as ex:
                     self._logger.exception(f"OS Error in message handler: {ex}")
                 except RuntimeError as ex:

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -735,7 +735,7 @@ class ExternalContext(InternalContext):
         # If no replies are defined, do not check for valid replies
         if not self._replies or received_digest not in self._replies:
             return
-        
+
         # If the replies is defined as the empty set, do not check for valid replies
         if self._replies[received_digest] == set():
             return

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -732,7 +732,12 @@ class ExternalContext(InternalContext):
         sender = self._message_received.sender
         received_digest = self._message_received.schema_digest
 
+        # If no replies are defined, do not check for valid replies
         if not self._replies or received_digest not in self._replies:
+            return
+        
+        # If the replies is defined as the empty set, do not check for valid replies
+        if self._replies[received_digest] == set():
             return
 
         valid_replies = set(self._replies[received_digest]) | {ERROR_MESSAGE_DIGEST}

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -732,6 +732,9 @@ class ExternalContext(InternalContext):
     def validate_replies(self, message_type: type[Model]) -> None:
         """
         If the context specifies replies, ensure that a valid reply was sent.
+
+        Args:
+            message_type (type[Model]): The type of the received message.
         """
         sender = self._message_received.sender
         received_digest = self._message_received.schema_digest

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -13,7 +13,7 @@ from cosmpy.aerial.client import LedgerClient
 from pydantic.v1 import ValidationError
 from uagents_core.envelope import Envelope
 from uagents_core.identity import parse_identifier
-from uagents_core.models import ERROR_MESSAGE_DIGEST, Model
+from uagents_core.models import ERROR_MESSAGE_DIGEST, ErrorMessage, Model
 from uagents_core.types import DeliveryStatus, MsgStatus
 
 from uagents.communication import dispatch_local_message
@@ -290,7 +290,7 @@ class InternalContext(Context):
         self._interval_messages = interval_messages
         self._wallet_messaging_client = wallet_messaging_client
         self._message_history = message_history
-        self._outbound_messages: dict[str, tuple[JsonStr, str]] = {}
+        self._outbound_messages: dict[str, list[tuple[JsonStr, str]]] = {}
 
     @property
     def agent(self) -> "AgentRepresentation":
@@ -319,12 +319,12 @@ class InternalContext(Context):
         return self._session
 
     @property
-    def outbound_messages(self) -> dict[str, tuple[JsonStr, str]]:
+    def outbound_messages(self) -> dict[str, list[tuple[JsonStr, str]]]:
         """
         Get the dictionary of outbound messages associated with the context.
 
         Returns:
-            dict[str, tuple[JsonStr, str]]: The dictionary of outbound messages.
+            dict[str, list[tuple[JsonStr, str]]]: The dictionary of outbound messages.
         """
         return self._outbound_messages
 
@@ -496,10 +496,14 @@ class InternalContext(Context):
                     session=self._session,
                 )
 
-            self._outbound_messages[parsed_address] = (
-                message_body,
-                message_schema_digest,
-            )
+            if parsed_address in self._outbound_messages:
+                self._outbound_messages[parsed_address].append(
+                    (message_body, message_schema_digest)
+                )
+            else:
+                self._outbound_messages[parsed_address] = [
+                    (message_body, message_schema_digest)
+                ]
 
         if result is None:
             # Resolve destination using the resolver
@@ -725,7 +729,7 @@ class ExternalContext(InternalContext):
         self._message_received = message_received
         self._protocol = protocol or ("", None)
 
-    def validate_replies(self) -> None:
+    def validate_replies(self, message_type: type[Model]) -> None:
         """
         If the context specifies replies, ensure that a valid reply was sent.
         """
@@ -736,23 +740,31 @@ class ExternalContext(InternalContext):
         if not self._replies or received_digest not in self._replies:
             return
 
-        # If the replies is defined as the empty set, do not check for valid replies
-        if self._replies[received_digest] == set():
+        # If replies are defined as empty, do not check for valid replies
+        if self._replies[received_digest] == {}:
             return
 
-        valid_replies = set(self._replies[received_digest]) | {ERROR_MESSAGE_DIGEST}
+        valid_replies = self._replies[received_digest] | {
+            ERROR_MESSAGE_DIGEST: ErrorMessage
+        }
 
         valid_reply_sent = False
-        for target, (_, schema_digest) in self._outbound_messages.items():
-            if target == sender and schema_digest in valid_replies:
+        for target, msgs in self._outbound_messages.items():
+            if target == sender and any(
+                [digest in valid_replies for _, digest in msgs]
+            ):
                 valid_reply_sent = True
                 break
 
         if not valid_reply_sent:
+            valid_reply_types = {model.__name__ for model in valid_replies.values()}
             log(
                 logger=self.logger,
                 level=logging.ERROR,
-                message=f"No valid reply was sent to {sender} for message: {received_digest}",
+                message=(
+                    f"No valid reply {valid_reply_types} was sent to "
+                    f"{sender} for received message: {message_type.__name__}."
+                ),
             )
 
     async def send(

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -139,6 +139,8 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(result, exp_msg_status)
+        with self.assertNoLogs(context.logger, level="ERROR"):
+            context.validate_replies(Incoming)
 
     async def test_send_local_dispatch_not_a_reply(self):
         context = self.get_external_context(
@@ -155,8 +157,12 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             endpoint="",
             session=context.session,
         )
-
         self.assertEqual(result, exp_msg_status)
+
+        with self.assertLogs(context.logger, level="ERROR") as log:
+            context.validate_replies(Incoming)
+            self.assertEqual(len(log.output), 1)
+            self.assertIn("No valid reply", log.output[0])
 
     async def test_send_local_dispatch_replies_not_validated(self):
         context = self.get_external_context(
@@ -174,6 +180,9 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             session=context.session,
         )
         self.assertEqual(result, exp_msg_status)
+
+        with self.assertNoLogs(context.logger, level="ERROR"):
+            context.validate_replies(Incoming)
 
     async def test_send_local_dispatch_valid_interval_msg(self):
         context = self.alice._build_context()


### PR DESCRIPTION
## Proposed Changes

Fixes erroneous logging errors on reply validation:
- Changes outbound message to a list in case multiple messages are sent to the same agent
- When replies are defined as empty, do not validate replies

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally
