### PR TITLE
chore(core): change type annotation so that agent category list is "allowed" to be sent via register_in_almanac

### DIFF
--- a/python/docs/api/uagents/registration.md
+++ b/python/docs/api/uagents/registration.md
@@ -7,8 +7,8 @@
 #### coerce_metadata_to_str[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/registration.py#L52)
 ```python
 def coerce_metadata_to_str(
-        metadata: dict[str, Any] | None
-) -> dict[str, str | dict[str, str]] | None
+    metadata: dict[str, Any] | None
+) -> dict[str, str | list[str] | dict[str, str]] | None
 ```
 
 Step through the metadata and convert any non-string values to strings.

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -51,7 +51,7 @@ class AgentStatusUpdate(VerifiableModel):
 
 def coerce_metadata_to_str(
     metadata: dict[str, Any] | None,
-) -> dict[str, str | dict[str, str]] | None:
+) -> dict[str, str | list[str] | dict[str, str]] | None:
     """Step through the metadata and convert any non-string values to strings."""
     if metadata is None:
         return None

--- a/python/tests/test_registration.py
+++ b/python/tests/test_registration.py
@@ -47,8 +47,8 @@ def test_attestation_signature_with_metadata():
             {
                 "foo": "bar",
                 "baz": 3.17,
-                "categories": ["apple", "orange", 2],
                 "qux": {"a": "b", "c": 4, "d": 5.6},
+                "quux": ["corge", "grault", 2],
             }
         ),
     )

--- a/python/tests/test_registration.py
+++ b/python/tests/test_registration.py
@@ -44,7 +44,12 @@ def test_attestation_signature_with_metadata():
         protocols=TEST_PROTOCOLS,
         endpoints=TEST_ENDPOINTS,
         metadata=coerce_metadata_to_str(
-            {"foo": "bar", "baz": 3.17, "qux": {"a": "b", "c": 4, "d": 5.6}}
+            {
+                "foo": "bar",
+                "baz": 3.17,
+                "categories": ["apple", "orange", 2],
+                "qux": {"a": "b", "c": 4, "d": 5.6},
+            }
         ),
     )
 

--- a/python/uagents-core/uagents_core/registration.py
+++ b/python/uagents-core/uagents_core/registration.py
@@ -70,7 +70,7 @@ class VerifiableModel(BaseModel):
 class AgentRegistrationAttestation(VerifiableModel):
     protocols: list[str]
     endpoints: list[AgentEndpoint]
-    metadata: dict[str, str | dict[str, str]] | None = None
+    metadata: dict[str, str | list[str] | dict[str, str]] | None = None
 
 
 # Agentverse related models

--- a/python/uagents-core/uagents_core/utils/registration.py
+++ b/python/uagents-core/uagents_core/utils/registration.py
@@ -67,7 +67,7 @@ def register_in_almanac(
     identity: Identity,
     endpoints: list[str],
     protocol_digests: list[str],
-    metadata: dict[str, str | dict[str, str]] | None = None,
+    metadata: dict[str, str | list[str] | dict[str, str]] | None = None,
     *,
     agentverse_config: AgentverseConfig | None = None,
     timeout: int = DEFAULT_REQUEST_TIMEOUT,


### PR DESCRIPTION
## Proposed Changes

Flockx business agents want to send list type registration metadata via the fetchai SDK (that uses uagents-core), that's why I changed the type annotation.

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
