### PR TITLE
feat(core): Add register_batch_in_almanac function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .env
 .history/*
 .coverage
+**/uagents_core.log

--- a/python/uagents-core/uagents_core/registration.py
+++ b/python/uagents-core/uagents_core/registration.py
@@ -77,7 +77,7 @@ class AgentRegistrationAttestationBatch(BaseModel):
     attestations: list[AgentRegistrationAttestation]
 
 
-class AgentRegistrationInput(BaseModel):
+class AgentRegistrationInput:
     identity: Identity
     endpoints: list[str]
     protocol_digests: list[str]

--- a/python/uagents-core/uagents_core/registration.py
+++ b/python/uagents-core/uagents_core/registration.py
@@ -73,7 +73,7 @@ class AgentRegistrationAttestation(VerifiableModel):
     metadata: dict[str, str | list[str] | dict[str, str]] | None = None
 
 
-class AgentRegistrationAttestationBatch(VerifiableModel):
+class AgentRegistrationAttestationBatch(BaseModel):
     attestations: list[AgentRegistrationAttestation]
 
 

--- a/python/uagents-core/uagents_core/registration.py
+++ b/python/uagents-core/uagents_core/registration.py
@@ -77,13 +77,6 @@ class AgentRegistrationAttestationBatch(BaseModel):
     attestations: list[AgentRegistrationAttestation]
 
 
-class AgentRegistrationInput:
-    identity: Identity
-    endpoints: list[str]
-    protocol_digests: list[str]
-    metadata: dict[str, str | list[str] | dict[str, str]] | None = None
-
-
 # Agentverse related models
 class RegistrationRequest(BaseModel):
     address: str

--- a/python/uagents-core/uagents_core/registration.py
+++ b/python/uagents-core/uagents_core/registration.py
@@ -73,6 +73,17 @@ class AgentRegistrationAttestation(VerifiableModel):
     metadata: dict[str, str | list[str] | dict[str, str]] | None = None
 
 
+class AgentRegistrationAttestationBatch(VerifiableModel):
+    attestations: list[AgentRegistrationAttestation]
+
+
+class AgentRegistrationInput(BaseModel):
+    identity: Identity
+    endpoints: list[str]
+    protocol_digests: list[str]
+    metadata: dict[str, str | list[str] | dict[str, str]] | None = None
+
+
 # Agentverse related models
 class RegistrationRequest(BaseModel):
     address: str

--- a/python/uagents-core/uagents_core/utils/registration.py
+++ b/python/uagents-core/uagents_core/utils/registration.py
@@ -28,7 +28,7 @@ from uagents_core.registration import (
     RegistrationRequest,
     RegistrationResponse,
 )
-from uagents_core.types import AgentEndpoint
+from uagents_core.types import AddressPrefix, AgentEndpoint
 
 logger = get_logger("uagents_core.utils.registration")
 
@@ -45,7 +45,7 @@ class AgentRegistrationInput:
         identity: Identity,
         endpoints: list[str],
         protocol_digests: list[str],
-        prefix: str | None = None,
+        prefix: AddressPrefix | None = None,
         metadata: dict[str, str | list[str] | dict[str, str]] | None = None,
     ):
         self.identity = identity
@@ -111,7 +111,7 @@ def register_in_almanac(
     endpoints: list[str],
     protocol_digests: list[str],
     metadata: dict[str, str | list[str] | dict[str, str]] | None = None,
-    prefix: str | None = None,
+    prefix: AddressPrefix | None = None,
     *,
     agentverse_config: AgentverseConfig | None = None,
     timeout: int = DEFAULT_REQUEST_TIMEOUT,
@@ -121,8 +121,7 @@ def register_in_almanac(
 
     Args:
         identity (Identity): The identity of the agent.
-        prefix (str | None): The Almanac contract where the agent will be registered.
-            If none is provided, the agent will be registered to the default contract.
+        prefix (AddressPrefix | None): The prefix for the agent identifier.
         endpoints (list[str]): The endpoints that the agent can be reached at.
         protocol_digests (list[str]): The digests of the protocol that the agent supports
         agentverse_config (AgentverseConfig): The configuration for the agentverse API

--- a/python/uagents-core/uagents_core/utils/registration.py
+++ b/python/uagents-core/uagents_core/utils/registration.py
@@ -213,7 +213,11 @@ def register_batch_in_almanac(
 
     logger.info(
         msg="Bulk registering with Almanac API",
-        extra=[attestation.agent_identifier for attestation in attestations],
+        extra={
+            "agent_addresses": [
+                attestation.agent_identifier for attestation in attestations
+            ]
+        },
     )
     attestation_batch = AgentRegistrationAttestationBatch(
         attestations=attestations,
@@ -222,7 +226,7 @@ def register_batch_in_almanac(
     # submit the attestation to the API
     status, _ = _send_post_request(
         url=f"{almanac_api}/agents/batch",
-        data=attestation_batch.model_dump_json(),
+        data=attestation_batch,
         timeout=timeout,
     )
     return status, invalid_identities

--- a/python/uagents-core/uagents_core/utils/registration.py
+++ b/python/uagents-core/uagents_core/utils/registration.py
@@ -121,6 +121,8 @@ def register_in_almanac(
 
     Args:
         identity (Identity): The identity of the agent.
+        prefix (str | None): The Almanac contract where the agent will be registered.
+            If none is provided, the agent will be registered to the default contract.
         endpoints (list[str]): The endpoints that the agent can be reached at.
         protocol_digests (list[str]): The digests of the protocol that the agent supports
         agentverse_config (AgentverseConfig): The configuration for the agentverse API


### PR DESCRIPTION
## Proposed Changes

Adds a `register_batch_in_almanac` function to registration utils, which utilizes the Almanac's [batch registration endpoint](https://github.com/fetchai/api-clients/blob/main/agentverse-client/agentverse_client/almanac/docs/AgentRegistrationAttestationBatch.md)

## Linked Issues

N/A

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

Because the `register_batch_in_almanac` function does not have unit tests or public-facing documentation, I didn't add any for this new function either. ~What is the recommended way to manually perform end-to-end tests for a new function like this?~ Changes were tested manually in a Python REPL.
