### PR TITLE
Update broken Fetch.ai agents documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You should see the results in your terminal.
 
 Please see the [official documentation](https://fetch.ai/docs) for full setup instructions and advanced features.
 
-- [👋 Introduction](https://fetch.ai/docs/concepts/agents/agents)
+- [👋 Introduction](https://fetch.ai/docs/concepts)
 - [💻 Installation](https://fetch.ai/docs/guides/agents/installing-uagent)
 - Tutorials
   - [🤖 Create an agent](https://fetch.ai/docs/guides/agents/create-a-uagent)


### PR DESCRIPTION
Replaced the outdated and broken link to the Fetch.ai agents concepts documentation in the README with the current valid URL (https://fetch.ai/docs/concepts). The new link provides up-to-date information about agents, their architecture, and usage within the Fetch.ai ecosystem.