### PR TITLE
feat(uagents-adapter/mcp): add new feature 'ResetTools', validation for arguments and 'session_id'

### DIFF
--- a/python/uagents-adapter/src/uagents_adapter/mcp/__init__.py
+++ b/python/uagents-adapter/src/uagents_adapter/mcp/__init__.py
@@ -3,7 +3,14 @@
 from importlib import metadata
 
 from .adapter import MCPServerAdapter
-from .protocol import CallTool, CallToolResponse, ListTools, ListToolsResponse
+from .protocol import (
+    CallTool,
+    CallToolResponse,
+    ListTools,
+    ListToolsResponse,
+    ResetTools,
+    ResetToolsResponse,
+)
 
 try:
     __version__ = metadata.version(__package__.split(".")[0])
@@ -19,5 +26,7 @@ __all__ = [
     "ListToolsResponse",
     "CallTool",
     "CallToolResponse",
+    "ResetTools",
+    "ResetToolsResponse",
     "__version__",
 ]

--- a/python/uagents-adapter/src/uagents_adapter/mcp/protocol.py
+++ b/python/uagents-adapter/src/uagents_adapter/mcp/protocol.py
@@ -1,6 +1,6 @@
 """Protocol definitions for MCP (Model Control Protocol)."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from uagents import Model
 from uagents_core.protocol import ProtocolSpecification
@@ -9,34 +9,53 @@ from uagents_core.protocol import ProtocolSpecification
 class ListTools(Model):
     """Request to list available tools."""
 
-    pass
+    session_id: str | None = None  # Add session ID
 
 
 class ListToolsResponse(Model):
     """Response containing available tools or error."""
 
-    tools: Optional[List[Dict[str, Any]]] = None
-    error: Optional[str] = None
+    tools: list[dict[str, Any]] | None = None
+    error: str | None = None
 
 
 class CallTool(Model):
     """Request to call a specific tool with arguments."""
 
+    request_id: str  # Unique request ID
+    session_id: str | None = None  # Add session ID
     tool: str
-    args: Dict[str, Any]
+    args: dict[str, Any]
 
 
 class CallToolResponse(Model):
     """Response from a tool call containing result or error."""
 
-    result: Optional[str] = None
-    error: Optional[str] = None
+    result: str | None = None
+    error: str | None = None
+
+
+class ResetTools(Model):
+    """Request to reset tool state for a session or globally."""
+
+    session_id: str | None = None  # Optional session ID for targeted reset
+
+
+class ResetToolsResponse(Model):
+    """Response indicating whether the reset was successful."""
+
+    success: bool
+    error: str | None = None
 
 
 # Protocol specification for MCP
 mcp_protocol_spec = ProtocolSpecification(
     name="MCPProtocol",
-    version="0.1.0",
-    interactions={ListTools: {ListToolsResponse}, CallTool: {CallToolResponse}},
-    roles={"client": set(), "server": {ListTools, CallTool}},
+    version="0.2.0",  # Updated version
+    interactions={
+        ListTools: {ListToolsResponse},
+        CallTool: {CallToolResponse},
+        ResetTools: {ResetToolsResponse},
+    },
+    roles={"client": set(), "server": {ListTools, CallTool, ResetTools}},
 )


### PR DESCRIPTION
## Proposed Changes

The ResetTools message type, introduced in the updated protocol.py and handled in adapter.py, is called when a client explicitly sends a ResetTools message to the server. This message is designed to clear session-specific state, such as the message history stored in ctx.storage or any internal state in the mcp_server (assuming that it supports a **reset_state** method).

The ResetTools message is part of the MCP protocol (mcp_protocol_spec). A client would send this message when it wants to reset the state for a specific session (identified by session_id).
For example, a client might send a ResetTools message:
-At the start of a new conversation to ensure no previous tool call parameters or message history are carried over.
-After completing a task to clear any cached data.
-In response to an error or unexpected behavior to reset the server’s state.

The updated adapter.py mitigates the issue by:
-Clearing message history on StartSessionContent.
-Filtering out role: tool messages in the ChatMessage handler.
-Validating tool arguments against inputSchema. These measures reduce the need for frequent ResetTools calls but don’t replace it entirely, as ResetTools provides a client-controlled mechanism for explicit state resets.

Nevertheless, I think that ResetTools may add up complexity on the client-side application. 

## Linked Issues

I have encountered issues when sending user-prompt via ASI1 or ChatProtocol to MCP agent. I have noticed that sometimes the mcp.tools() function would use the arguments from the previous prompt. My assumption was that there is some buffer/resources that are not cleared (cached).

<img width="1048" alt="Screenshot 2025-07-02 at 20 18 05" src="https://github.com/user-attachments/assets/df55f638-1867-4eca-aa77-2bf0d401d266" />

Otherwise, I believe there should be something implemented internally both for function parameter checks and reset_state to simplify the client-side implementation.

There is a chance that I missed something in the current stack implementation that should tackle the issue, FastMCP, or this provided solution/idea is not viable, however, I would highly appreciate the feedback!

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

Whether FastMCP class from the mcp.server.fastmcp module has implementation of a reset_state method or not,  this could affect how the ResetTools message is handled in the updated adapter.py and whether additional modifications are needed.

Thanks