### PR TITLE
feat(core): better handling of agent prefix in domain resolution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # The default code owners of the uagents repo.
-* @jrriehl @Archento @lrahmani @qati
+* @jrriehl @Archento @lrahmani @qati @Alejandro-Morales


### PR DESCRIPTION
## Proposed Changes

Use the agent prefix to determine which contract should be queried for agent domains (testnet or mainnet). If no prefix is provided, prefer mainnet if both exist.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [ ] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
