### PR TITLE
feat(core) - Add Helper Utilities to Reduce Agent Chat Protocol Boilerplate in uagents_core

### DIFF
--- a/python/uagents-core/uagents_core/contrib/protocols/chat/__init__.py
+++ b/python/uagents-core/uagents_core/contrib/protocols/chat/__init__.py
@@ -1,14 +1,20 @@
 """
-This module contains the protocol specification for the agent chat protocol.
+This module contains the protocol specification for the agent chat protocol,
+plus a ready‐to‐use Protocol instance and message‐building helpers.
 """
 
 from datetime import datetime
-from typing import Literal, TypedDict
+from datetime import timezone as _timezone
+from typing import Literal, TypedDict, Union
+from uuid import uuid4
 
 from pydantic.v1 import UUID4
+from uagents import Context, Protocol
 
 from uagents_core.models import Model
 from uagents_core.protocol import ProtocolSpecification
+
+# --- Original content models & spec ---------------------------------------
 
 
 class Metadata(TypedDict):
@@ -122,3 +128,71 @@ chat_protocol_spec = ProtocolSpecification(
         ChatAcknowledgement: set(),
     },
 )
+
+
+# --- Ready‐to‐use Protocol instance & helpers -----------------------------
+
+# A Protocol instance preconfigured with the chat spec and a default ACK handler.
+chat_proto = Protocol(spec=chat_protocol_spec)
+
+
+@chat_proto.on_message(ChatAcknowledgement)
+async def _default_handle_ack(ctx: Context, sender: str, msg: ChatAcknowledgement):
+    ctx.logger.info(
+        f"Got an acknowledgement from {sender} for {msg.acknowledged_msg_id}"
+    )
+
+
+class ChatObjects:
+    """
+    Utility class for constructing ChatMessage objects with common content types.
+    """
+
+    @classmethod
+    def text(cls, text: str, end_session: bool = False) -> ChatMessage:
+        """
+        Create a ChatMessage with TextContent.
+        Pass end_session=True to append an EndSessionContent.
+        """
+        contents: list[AgentContent] = [TextContent(type="text", text=text)]
+        if end_session:
+            contents.append(EndSessionContent(type="end-session"))
+        return ChatMessage(
+            timestamp=datetime.now(_timezone.utc),
+            msg_id=uuid4(),
+            content=contents,
+        )
+
+    @classmethod
+    def end_session(cls) -> ChatMessage:
+        """
+        Create a ChatMessage that signals end of session.
+        """
+        return ChatMessage(
+            timestamp=datetime.now(_timezone.utc),
+            msg_id=uuid4(),
+            content=[EndSessionContent(type="end-session")],
+        )
+
+    @classmethod
+    def resource(
+        cls,
+        asset_id: Union[str, UUID4],
+        uri: str,
+        mime_type: str = "image/png",
+        role: str = "generated-resource",
+    ) -> ChatMessage:
+        """
+        Create a ChatMessage carrying a ResourceContent (e.g. image/file).
+        """
+        res_id = UUID4(asset_id) if isinstance(asset_id, str) else asset_id
+        rc = ResourceContent(
+            type="resource",
+            resource_id=res_id,
+            resource=Resource(uri=uri, metadata={"mime_type": mime_type, "role": role}),
+        )
+        return ChatMessage(
+            timestamp=datetime.now(_timezone.utc),
+            msg_id=uuid4(),
+            content=[rc],
+        )


### PR DESCRIPTION
## Proposed Changes

Added common chat protocol models, a pre-configured `chat_proto`, and grouped helper methods into a single `ChatObjects` utility class.

## Linked Issues

- Consolidated all chat content models, the `chat_protocol_spec`, and message types (`ChatMessage`, `ChatAcknowledgement`) into `uagents_core/contrib/protocols/chat/__init__.py`.
- Created a single, ready‑to‑use chat_proto instance with a default ACK handler.
- Introduced a new `ChatObjects` class with class‑methods `.text()`, `.end_session()`, and `.resource()` to replace free‑function helpers.
- Removed duplicate helper code from individual agents and updated their imports to use `chat_proto` and `ChatObjects`.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

Grouping all chat‑related utilities into one module and a single helper class reduces code duplication, and makes future extensions (e.g. new content types) straightforward—just add another ChatObjects method and register any protocol handlers in one place.
