### PR TITLE
feat(core): add constructors with default values to chat messages

### DIFF
--- a/python/uagents-core/uagents_core/contrib/protocols/chat/__init__.py
+++ b/python/uagents-core/uagents_core/contrib/protocols/chat/__init__.py
@@ -2,8 +2,9 @@
 This module contains the protocol specification for the agent chat protocol.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal, TypedDict
+from uuid import uuid4
 
 from pydantic.v1 import UUID4
 
@@ -27,6 +28,9 @@ class TextContent(Model):
     # markdown based formatting can be used and will be supported by most clients
     text: str
 
+    def __init__(self, text: str):
+        super().__init__(type="text", text=text)
+
 
 class Resource(Model):
     # the uri of the resource
@@ -35,6 +39,9 @@ class Resource(Model):
     # the set of metadata for this resource, for more detailed description of the set of
     # fields see `docs/metadata.md`
     metadata: dict[str, str]
+
+    def __init__(self, uri: str, metadata: dict[str, str] | None = None):
+        super().__init__(uri=uri, metadata=metadata or {})
 
 
 class ResourceContent(Model):
@@ -51,6 +58,9 @@ class ResourceContent(Model):
     # considered the primary resource
     resource: Resource | list[Resource]
 
+    def __init__(self, resource_id: UUID4, resource: Resource | list[Resource]):
+        super().__init__(type="resource", resource_id=resource_id, resource=resource)
+
 
 class MetadataContent(Model):
     type: Literal["metadata"]
@@ -59,13 +69,22 @@ class MetadataContent(Model):
     # fields see `docs/metadata.md`
     metadata: dict[str, str]
 
+    def __init__(self, metadata: dict[str, str]):
+        super().__init__(type="metadata", metadata=metadata)
+
 
 class StartSessionContent(Model):
     type: Literal["start-session"]
 
+    def __init__(self):
+        super().__init__(type="start-session")
+
 
 class EndSessionContent(Model):
     type: Literal["end-session"]
+
+    def __init__(self):
+        super().__init__(type="end-session")
 
 
 class StartStreamContent(Model):
@@ -73,11 +92,17 @@ class StartStreamContent(Model):
 
     stream_id: UUID4
 
+    def __init__(self, stream_id: UUID4):
+        super().__init__(type="start-stream", stream_id=stream_id)
+
 
 class EndStreamContent(Model):
     type: Literal["end-stream"]
 
     stream_id: UUID4
+
+    def __init__(self, stream_id: UUID4):
+        super().__init__(type="end-stream", stream_id=stream_id)
 
 
 # The combined agent content types
@@ -102,6 +127,16 @@ class ChatMessage(Model):
     # the list of content elements in the chat
     content: list[AgentContent]
 
+    def __init__(
+        self,
+        content: list[AgentContent],
+        msg_id: UUID4 | None = None,
+        timestamp: datetime | None = None,
+    ):
+        msg_id = msg_id or uuid4()
+        timestamp = timestamp or datetime.now(timezone.utc)
+        super().__init__(timestamp=timestamp, msg_id=msg_id, content=content)
+
 
 class ChatAcknowledgement(Model):
     # the timestamp for the message, should be in UTC
@@ -112,6 +147,19 @@ class ChatAcknowledgement(Model):
 
     # optional acknowledgement metadata
     metadata: dict[str, str] | None = None
+
+    def __init__(
+        self,
+        acknowledged_msg_id: UUID4,
+        metadata: dict[str, str] | None = None,
+        timestamp: datetime | None = None,
+    ):
+        timestamp = timestamp or datetime.now(timezone.utc)
+        super().__init__(
+            timestamp=timestamp,
+            acknowledged_msg_id=acknowledged_msg_id,
+            metadata=metadata,
+        )
 
 
 chat_protocol_spec = ProtocolSpecification(


### PR DESCRIPTION
## Proposed Changes

Provide constructors with default values for a more user-friendly interface for creating chat messages and content. We add constructors instead of adding defaults to the pydantic models to preserve the current protocol digest. On the next breaking update to the protocol, it might be better to add these as default values.

This will allow creating basic chat messages like:
```python
  text_msg = ChatMessage([TextContent("Hello!")])

  res_id =uuid4()
  resource_msg = ChatMessage(
      [
          ResourceContent(
              res_id,
              Resource(uri=f"agent-storage://agentverse.ai/{res_id}"),
          ),
          EndSessionContent(),
      ]
  )
```


## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
