### PR TITLE
chore(uagents): set missing mailbox log level to warning and only log once

### DIFF
--- a/python/docs/api/uagents/mailbox.md
+++ b/python/docs/api/uagents/mailbox.md
@@ -97,7 +97,7 @@ Client for interacting with the Agentverse mailbox server.
 
 
 
-#### run[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/mailbox.py#L227)
+#### run[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/mailbox.py#L228)
 ```python
 async def run()
 ```

--- a/python/src/uagents/mailbox.py
+++ b/python/src/uagents/mailbox.py
@@ -223,6 +223,7 @@ class MailboxClient:
         self._access_token: str | None = None
         self._poll_interval = MAILBOX_POLL_INTERVAL_SECONDS
         self._logger = logger or get_logger("mailbox")
+        self._missing_mailbox_warning_logged = False
 
     async def run(self):
         """Runs the mailbox client."""
@@ -255,6 +256,12 @@ class MailboxClient:
                             self._logger.warning(
                                 "Access token expired: a new one should be retrieved automatically"
                             )
+                        elif resp.status == 404:
+                            if not self._missing_mailbox_warning_logged:
+                                self._logger.warning(
+                                    "Agent mailbox not found: create one using the agent inspector"
+                                )
+                                self._missing_mailbox_warning_logged = True
                         else:
                             self._logger.error(
                                 f"Failed to retrieve messages: {resp.status}:{(await resp.text())}"


### PR DESCRIPTION
## Proposed Changes

Before an agent's mailbox is setup, it will try to check messages and receive a 404 error from the server. Instead of logging this as an error, inform the user where to create a mailbox and only log this once.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
