### PR TITLE
fix(uagents): do not check expiry in almanac api resolver

### DIFF
--- a/python/src/uagents/resolver.py
+++ b/python/src/uagents/resolver.py
@@ -3,11 +3,10 @@
 import logging
 import random
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
+from datetime import datetime
 from enum import Enum
 
 import aiohttp
-from dateutil import parser
 from pydantic import BaseModel
 from uagents_core.helpers import weighted_random_sample
 from uagents_core.identity import parse_identifier
@@ -306,11 +305,9 @@ class AlmanacApiResolver(Resolver):
             if expiry_str is None:
                 return None, []
 
-            expiry = parser.parse(expiry_str)
-            current_time = datetime.now(timezone.utc)
             endpoint_list = agent.get("endpoints", [])
 
-            if len(endpoint_list) > 0 and expiry > current_time:
+            if len(endpoint_list) > 0:
                 endpoints = [val.get("url") for val in endpoint_list]
                 weights = [val.get("weight") for val in endpoint_list]
                 return address, weighted_random_sample(


### PR DESCRIPTION
## Proposed Changes

Based on the discussion with Attila and James we don't want to check expiry in Almanac API resolver.

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
