### PR TITLE
feat(experimental): Add BlockRun.AI as LLM provider

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,9 +23,11 @@ dependencies = [
 all = [
     "fetchai-babble >=0.4.5",
     "litellm >=1.78.6,<2.0",
+    "blockrun-llm >=0.2.0",
 ]
 wallet = ["fetchai-babble >=0.4.5"]
 llm = ["litellm >=1.78.6,<2.0"]
+blockrun = ["blockrun-llm >=0.2.0"]
 
 [project.urls]
 homepage = "https://fetch.ai"

--- a/python/src/uagents/experimental/chat_agent/README.md
+++ b/python/src/uagents/experimental/chat_agent/README.md
@@ -77,6 +77,31 @@ claude_config = LLMConfig(
 agent = ChatAgent(name="MathChat", llm_config=asione_config)
 ```
 
+### BlockRun.AI (Pay-per-request with x402)
+
+BlockRun provides access to multiple LLM providers with pay-per-request micropayments on Base chain. No API keys needed - just a wallet.
+
+```bash
+pip install uagents[blockrun]
+```
+
+```python
+from uagents.experimental.chat_agent import ChatAgent, LLMConfig
+
+# Set BLOCKRUN_WALLET_KEY env var or pass wallet_key directly
+blockrun_config = LLMConfig.blockrun(model="openai/gpt-4o")
+
+# Available models:
+# - openai/gpt-4o, openai/gpt-4o-mini
+# - anthropic/claude-sonnet-4
+# - google/gemini-2.0-flash
+# - deepseek/deepseek-chat
+
+agent = ChatAgent(name="MathChat", llm_config=blockrun_config)
+```
+
+Learn more: https://blockrun.ai/docs
+
 ## LLMParams defaults:
 
 * `temperature` = 0.0: make the model as deterministic as possible (no randomness in choices).


### PR DESCRIPTION
## Add BlockRun.AI as LLM Provider

BlockRun.AI is a pay-per-request AI gateway using x402 micropayments on Base. No API keys needed - just a wallet.

### Why BlockRun?
- Access GPT-4o, Claude, Gemini, DeepSeek via single integration
- Pay-per-request in USDC (no monthly subscriptions)
- Private key never leaves your machine (local EIP-712 signing)

### Changes
- Added `LLMConfig.blockrun()` factory method for easy configuration
- Modified `LLM` class to detect BlockRun provider and use official `blockrun-llm` SDK
- Added `blockrun-llm` as optional dependency (`pip install uagents[blockrun]`)
- Updated `chat_agent` README with BlockRun usage examples

### Usage

```python
from uagents.experimental.chat_agent import ChatAgent, LLMConfig

# Set BLOCKRUN_WALLET_KEY env var
config = LLMConfig.blockrun(model="openai/gpt-4o")
agent = ChatAgent(name="MyAgent", llm_config=config)
```

### Available Models
- `openai/gpt-4o`, `openai/gpt-4o-mini`
- `anthropic/claude-sonnet-4`
- `google/gemini-2.0-flash`
- `deepseek/deepseek-chat`

### Links
- [BlockRun Docs](https://blockrun.ai/docs)
- [Python SDK](https://github.com/blockrunai/blockrun-llm)