### PR TITLE
fix(uagents): store external msgs only once in history

### DIFF
--- a/python/docs/api/uagents/communication.md
+++ b/python/docs/api/uagents/communication.md
@@ -6,7 +6,7 @@ Agent dispatch of exchange envelopes and synchronous messages.
 
 
 
-## Dispenser Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L28)
+## Dispenser Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L25)
 
 ```python
 class Dispenser()
@@ -16,7 +16,7 @@ Dispenses messages externally.
 
 
 
-#### add_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L37)
+#### add_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L33)
 ```python
 def add_envelope(envelope: Envelope,
                  endpoints: list[str],
@@ -35,7 +35,7 @@ Add an envelope to the dispenser.
 
 
 
-#### run[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L84)
+#### run[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L80)
 ```python
 async def run() -> None
 ```
@@ -44,7 +44,7 @@ Run the dispenser routine.
 
 
 
-#### dispatch_local_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L106)
+#### dispatch_local_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L102)
 ```python
 async def dispatch_local_message(sender: str, destination: str,
                                  schema_digest: str, message: JsonStr,
@@ -55,7 +55,7 @@ Process a message locally.
 
 
 
-#### send_exchange_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L130)
+#### send_exchange_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L126)
 ```python
 async def send_exchange_envelope(envelope: Envelope,
                                  endpoints: list[str],
@@ -77,7 +77,7 @@ Method to send an exchange envelope.
 
 
 
-#### dispatch_sync_response_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L204)
+#### dispatch_sync_response_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L200)
 ```python
 async def dispatch_sync_response_envelope(
         env: Envelope, endpoint: str) -> MsgStatus | Envelope
@@ -87,7 +87,7 @@ Dispatch a synchronous response envelope locally.
 
 
 
-#### send_message_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L227)
+#### send_message_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L223)
 ```python
 async def send_message_raw(
         destination: str,
@@ -123,7 +123,7 @@ Standalone function to send a message to an agent.
 
 
 
-#### send_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L306)
+#### send_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L302)
 ```python
 async def send_message(
         destination: str,
@@ -157,7 +157,7 @@ Standalone function to send a message to an agent.
 
 
 
-#### send_sync_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L345)
+#### send_sync_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L341)
 ```python
 async def send_sync_message(
     destination: str,
@@ -191,7 +191,7 @@ Standalone function to send a synchronous message to an agent.
 
 
 
-#### enclose_response[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L382)
+#### enclose_response[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L378)
 ```python
 def enclose_response(message: Model,
                      sender: str,
@@ -215,7 +215,7 @@ Enclose a response message within an envelope.
 
 
 
-#### enclose_response_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L407)
+#### enclose_response_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L403)
 ```python
 def enclose_response_raw(json_message: JsonStr,
                          schema_digest: str,

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -406,7 +406,7 @@ class Agent(Sink):
             if enable_agent_inspector or store_message_history
             else None
         )
-        self._dispenser = Dispenser(msg_cache_ref=self._message_history)
+        self._dispenser = Dispenser()
         self._message_queue = asyncio.Queue()
         self._message_tasks: set[asyncio.Task] = set()
         self._interval_tasks: set[asyncio.Task] = set()

--- a/python/src/uagents/communication.py
+++ b/python/src/uagents/communication.py
@@ -16,10 +16,7 @@ from uagents_core.types import DeliveryStatus, MsgStatus
 from uagents.config import DEFAULT_ENVELOPE_TIMEOUT_SECONDS
 from uagents.dispatch import dispatcher
 from uagents.resolver import GlobalResolver, Resolver
-from uagents.types import (
-    EnvelopeHistory,
-    JsonStr,
-)
+from uagents.types import JsonStr
 from uagents.utils import get_logger
 
 LOGGER: logging.Logger = get_logger("dispenser", logging.DEBUG)
@@ -28,11 +25,10 @@ LOGGER: logging.Logger = get_logger("dispenser", logging.DEBUG)
 class Dispenser:
     """Dispenses messages externally."""
 
-    def __init__(self, msg_cache_ref: EnvelopeHistory | None = None):
+    def __init__(self):
         self._envelopes: asyncio.Queue[
             tuple[Envelope, list[str], asyncio.Future, bool]
         ] = asyncio.Queue()
-        self._msg_cache_ref = msg_cache_ref
 
     def add_envelope(
         self,


### PR DESCRIPTION
## Proposed Changes

External outgoing messages were getting stored in session history twice.


## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)