### PR TITLE
fix(a2a-adapter): add follow_redirects=True to httpx AsyncClient calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,19 @@ You should see the results in your terminal.
 
 ## 📖 Documentation
 
-Please see the [official documentation](https://fetch.ai/docs) for full setup instructions and advanced features.
+Please see the [official documentation](https://uagents.fetch.ai/docs) for full setup instructions and advanced features.
 
-- [👋 Introduction](https://fetch.ai/docs/concepts)
-- [💻 Installation](https://fetch.ai/docs/guides/agents/installing-uagent)
+- [👋 Introduction](https://uagents.fetch.ai/docs)
+- [💻 Installation](https://uagents.fetch.ai/docs/getting-started/install)
 - Tutorials
-  - [🤖 Create an agent](https://fetch.ai/docs/guides/agents/create-a-uagent)
-  - [🛣️ Agent Communication](https://fetch.ai/docs/guides/agents/communicating-with-other-agents)
-  - [🍽️ Restaurant Booking Demo](https://fetch.ai/docs/guides/agents/booking-demo)
+  - [🤖 Create an Agent](https://uagents.fetch.ai/docs/getting-started/create)
+  - [🛣️ Agent Communication](https://uagents.fetch.ai/docs/guides/communication)
+  - [🍽️ ASI:One Compatible Agent](https://uagents.fetch.ai/docs/examples/asi-1)
 - Key Concepts:
-  - [📍Addresses](https://fetch.ai/docs/guides/agents/getting-uagent-address)
-  - [💾 Storage](https://fetch.ai/docs/guides/agents/storage-function)
-  - [📝 Interval Tasks](https://fetch.ai/docs/guides/agents/interval-task)
-  - [🌐 Agent Broadcast](https://fetch.ai/docs/guides/agents/broadcast)
-  - [⚙️ Almanac Contracts](https://fetch.ai/docs/guides/agents/register-in-almanac)
+  - [📍Addresses](https://uagents.fetch.ai/docs/getting-started/address)
+  - [💾 Storage](https://uagents.fetch.ai/docs/guides/storage)
+  - [📝 Synchronous Communication](https://uagents.fetch.ai/docs/guides/send_receive)
+  - [🌐 Agent Broadcast](https://uagents.fetch.ai/docs/guides/broadcast)
 
 ## 🌱 Examples and Integrations
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,68 @@
+# uAgents Python Packages
+
+This directory contains the Python packages for the uAgents framework.
+
+## Packages
+
+| Package | Description | PyPI |
+|---------|-------------|------|
+| **[uagents](src/uagents/)** | Main agent framework with decorators and runtime | [![PyPI](https://img.shields.io/pypi/v/uagents)](https://pypi.org/project/uagents/) |
+| **[uagents-core](uagents-core/)** | Core definitions for Agentverse integration | [![PyPI](https://img.shields.io/pypi/v/uagents-core)](https://pypi.org/project/uagents-core/) |
+| **[uagents-adapter](uagents-adapter/)** | Adapters for LangChain, CrewAI, MCP | [![PyPI](https://img.shields.io/pypi/v/uagents-adapter)](https://pypi.org/project/uagents-adapter/) |
+| **[uagents-ai-engine](uagents-ai-engine/)** | AI Engine integration | [![PyPI](https://img.shields.io/pypi/v/uagents-ai-engine)](https://pypi.org/project/uagents-ai-engine/) |
+
+## Installation
+
+### Full Framework
+
+```bash
+pip install uagents
+```
+
+### Core Only (for custom integrations)
+
+```bash
+pip install uagents-core
+```
+
+## Development Setup
+
+1. Install Poetry:
+   ```bash
+   pip install poetry
+   ```
+
+2. Install dependencies:
+   ```bash
+   cd python
+   poetry install
+   poetry shell
+   pre-commit install
+   ```
+
+3. Run tests:
+   ```bash
+   pytest
+   ```
+
+4. Format and lint:
+   ```bash
+   ruff check --fix && ruff format
+   ```
+
+## Documentation
+
+- **[API Documentation](docs/api/)** - Auto-generated API docs
+- **[Upgrading Guide](docs/UPGRADING.md)** - Migration between versions
+- **[Official Docs](https://uagents.fetch.ai/docs)** - Full documentation
+
+## Version Compatibility
+
+| uagents | uagents-core | Python |
+|---------|--------------|--------|
+| 0.23.x | >=0.4.0 | 3.10-3.13 |
+| 0.22.x | 0.3.x | 3.10-3.12 |
+
+## Contributing
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.

--- a/python/docs/UPGRADING.md
+++ b/python/docs/UPGRADING.md
@@ -1,0 +1,258 @@
+# Upgrading uAgents / uagents-core
+
+This guide helps you migrate between major versions of uAgents and uagents-core.
+
+## Table of Contents
+
+- [From uagents-core 0.3.x to 0.4.0](#from-uagents-core-03x-to-040)
+- [Version Compatibility Matrix](#version-compatibility-matrix)
+
+---
+
+## From uagents-core 0.3.x to 0.4.0
+
+### Overview
+
+Version 0.4.0 introduces a **simplified registration model** with significant architectural changes:
+
+| Aspect | 0.3.x | 0.4.0 |
+|--------|-------|-------|
+| Registration expiration | 48 hours | **Permanent** (no expiration) |
+| Almanac registration | Separate API call required | **Automatic** (handled by Agentverse) |
+| Periodic refresh | Required every ~46 hours | **Not needed** |
+| Batch registration | Supported | **Deprecated** |
+
+### Key Benefits
+
+1. **Register once** - No need for periodic refresh tasks
+2. **Simpler architecture** - Agentverse handles Almanac synchronization
+3. **Reduced complexity** - Remove expiration tracking and refresh infrastructure
+
+---
+
+### Breaking Changes
+
+#### Registration API Changes
+
+| 0.3.x | 0.4.0 | Notes |
+|-------|-------|-------|
+| `AgentRegistrationInput` | `RegistrationRequest` | New model with different fields |
+| `register_batch_in_almanac()` | **Deprecated** | Use `register_in_agentverse()` individually |
+| N/A | `register_in_agentverse()` | New primary registration function |
+| N/A | DELETE `/v2/agents/{address}` | New agent removal capability |
+
+#### New Required Fields
+
+The `RegistrationRequest` model requires fields that were optional in `AgentRegistrationInput`:
+
+```python
+from uagents_core.registration import RegistrationRequest, AgentProfile
+
+# 0.4.0 requires these fields:
+request = RegistrationRequest(
+    address="agent1q...",           # Required: bech32 agent address
+    name="My Agent",                # Required: 1-80 characters
+    agent_type="proxy",             # Optional: defaults to "uagent"
+    profile=AgentProfile(           # Optional: agent profile
+        description="Short desc",   # Max 300 chars
+        readme="Detailed readme",   # Max 80000 chars
+        avatar_url="https://...",   # Max 4000 chars
+    ),
+    endpoints=[...],                # Optional: list of AgentEndpoint
+    protocols=[...],                # Optional: list of protocol digests
+    metadata={...},                 # Optional: additional metadata
+)
+```
+
+#### Handle Uniqueness
+
+The `handle` field in `RegistrationRequest` is now **globally unique**. Choose handles carefully as they cannot be reused across the platform.
+
+---
+
+### Migration Guide
+
+#### Step 1: Update Dependencies
+
+```bash
+pip install uagents-core>=0.4.0
+```
+
+Or in your requirements file:
+
+```
+uagents-core>=0.4.0,<0.5.0
+```
+
+#### Step 2: Update Registration Code
+
+**Before (0.3.x) - Batch registration with periodic refresh:**
+
+```python
+from uagents_core.utils.registration import (
+    AgentRegistrationInput,
+    register_batch_in_almanac,
+)
+
+# This was called every ~2 hours to refresh before 48hr expiration
+def refresh_registrations():
+    items = [
+        AgentRegistrationInput(
+            identity=identity,
+            endpoints=[endpoint],
+            protocol_digests=[protocol_digest],
+            metadata={"key": "value"},
+        )
+        for agent in agents_to_refresh
+    ]
+    
+    success, failed = register_batch_in_almanac(items, agentverse_config=config)
+```
+
+**After (0.4.0) - Individual registration, once per agent:**
+
+```python
+from uagents_core.utils.registration import (
+    register_in_agentverse,
+    AgentverseRegistrationRequest,
+)
+from uagents_core.registration import AgentverseConnectRequest
+from uagents_core.identity import Identity
+from uagents_core.config import AgentverseConfig
+
+def register_agent(agent_seed: str, name: str, endpoint: str, api_key: str) -> bool:
+    """
+    Register an agent to Agentverse. Call once on agent creation.
+    Registration is permanent - no refresh needed.
+    """
+    identity = Identity.from_seed(agent_seed, 0)
+    
+    connect_request = AgentverseConnectRequest(
+        user_token=api_key,
+        agent_type="proxy",
+        endpoint=endpoint,
+    )
+    
+    agent_details = AgentverseRegistrationRequest(
+        name=name,
+        endpoint=endpoint,
+        protocols=[your_protocol_digest],
+        description="Agent description",
+        readme="Detailed agent readme",
+    )
+    
+    return register_in_agentverse(
+        request=connect_request,
+        identity=identity,
+        agent_details=agent_details,
+        agentverse_config=AgentverseConfig(),
+    )
+```
+
+#### Step 3: Remove Refresh Infrastructure
+
+Since registrations are now permanent, you can remove:
+
+- **Periodic refresh tasks** (Celery, cron jobs, etc.)
+- **Expiration tracking** (e.g., `last_registered_at` timestamps)
+- **Refresh interval settings**
+- **Batch registration code**
+
+#### Step 4: Update Agent Removal (Optional)
+
+If you need to remove agents from Agentverse, use the new DELETE endpoint:
+
+```python
+import requests
+
+def delete_agent(agent_address: str, api_key: str) -> bool:
+    """Remove an agent from Agentverse."""
+    response = requests.delete(
+        f"https://agentverse.ai/v2/agents/{agent_address}",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    return response.status_code == 200
+```
+
+---
+
+### Batch Registration Deprecation
+
+**Batch registration is deprecated in 0.4.0.** Since registrations no longer expire, there's no need to refresh multiple agents simultaneously.
+
+For large imports or backfills:
+
+```python
+import time
+
+def backfill_agents(agents: list, api_key: str):
+    """Register multiple agents with rate limiting."""
+    for agent in agents:
+        success = register_agent(
+            agent_seed=agent.seed,
+            name=agent.name,
+            endpoint=agent.endpoint,
+            api_key=api_key,
+        )
+        if success:
+            print(f"Registered: {agent.name}")
+        else:
+            print(f"Failed: {agent.name}")
+        
+        # Rate limit: wait between requests
+        time.sleep(0.1)
+```
+
+---
+
+### API Endpoints Reference
+
+| Purpose | v1 (deprecated) | v2 (current) |
+|---------|-----------------|--------------|
+| Agent registration | `/v1/almanac` | `/v2/agents` |
+| Identity proof | N/A | `/v2/identity` |
+| Agent removal | N/A | DELETE `/v2/agents/{address}` |
+
+The v2 API automatically syncs registrations to Almanac. You no longer need to call `/v1/almanac` directly.
+
+---
+
+### FAQ
+
+**Q: Do I still need to refresh registrations periodically?**
+
+No. V2 registrations are permanent. Agentverse handles Almanac synchronization automatically.
+
+**Q: What happens to my existing agents registered via v1?**
+
+They will continue to work. However, you should migrate to v2 and remove your refresh infrastructure.
+
+**Q: Can I still use batch registration?**
+
+The function exists for backwards compatibility, but it's deprecated. Use individual `register_in_agentverse()` calls instead.
+
+**Q: How do I update an agent's profile after registration?**
+
+Call `register_in_agentverse()` again with the updated details. It will update the existing registration.
+
+**Q: How do I remove an agent from Agentverse?**
+
+Use the DELETE endpoint: `DELETE /v2/agents/{agent_address}`
+
+---
+
+## Version Compatibility Matrix
+
+| uagents | uagents-core | Python | Notes |
+|---------|--------------|--------|-------|
+| 0.23.x | >=0.4.0 | 3.10-3.13 | Current version |
+| 0.22.x | 0.3.x | 3.10-3.12 | Requires periodic refresh |
+| 0.21.x | 0.3.x | 3.10-3.12 | Requires periodic refresh |
+
+---
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/fetchai/uAgents/issues) - Bug reports and feature requests
+- [GitHub Discussions](https://github.com/fetchai/uAgents/discussions) - Questions and general discussion
+- [Official Documentation](https://uagents.fetch.ai/docs) - Full documentation

--- a/python/docs/UPGRADING.md
+++ b/python/docs/UPGRADING.md
@@ -4,13 +4,13 @@ This guide helps you migrate between major versions of uAgents and uagents-core.
 
 ## Table of Contents
 
-- [Error Propagation Fix (0.4.x)](#error-propagation-fix-04x)
+- [Error Propagation Fix (0.4.1)](#error-propagation-fix-041)
 - [From uagents-core 0.3.x to 0.4.0](#from-uagents-core-03x-to-040)
 - [Version Compatibility Matrix](#version-compatibility-matrix)
 
 ---
 
-## Error Propagation Fix (0.4.x)
+## Error Propagation Fix (0.4.1)
 
 ### What Changed
 
@@ -294,7 +294,7 @@ Call `register_chat_agent()` or `register_agent()` again with the updated detail
 
 **Q: How do I handle registration errors?**
 
-Wrap `register_chat_agent()` or `register_agent()` in a try/except for `AgentverseRequestError`. See the [Error Propagation Fix](#error-propagation-fix-04x) section for examples.
+Wrap `register_chat_agent()` or `register_agent()` in a try/except for `AgentverseRequestError`. See the [Error Propagation Fix](#error-propagation-fix-041) section for examples.
 
 **Q: How do I remove an agent from Agentverse?**
 

--- a/python/uagents-adapter/src/uagents_adapter/a2a_outbound/adapter.py
+++ b/python/uagents-adapter/src/uagents_adapter/a2a_outbound/adapter.py
@@ -275,7 +275,7 @@ class SingleA2AAdapter:
 
         Returns either a text string or AP2 objects (CartMandate, PaymentSuccess/Failure).
         """
-        async with httpx.AsyncClient() as httpx_client:
+        async with httpx.AsyncClient(follow_redirects=True) as httpx_client:
             try:
                 # Try the correct A2A endpoint format
                 if isinstance(message, dict):
@@ -659,7 +659,7 @@ class MultiA2AAdapter:
         self.discovered_agents = {}
         self.agent_health = {}
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             for config in self.agent_configs:
                 try:
                     # Prefer new endpoint; fallback to legacy for compatibility
@@ -885,7 +885,7 @@ class MultiA2AAdapter:
                 "Authorization": f"Bearer {self.llm_api_key}",
             }
 
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(follow_redirects=True) as client:
                 response = await client.post(
                     url, headers=headers, json=payload, timeout=10
                 )
@@ -945,7 +945,7 @@ class MultiA2AAdapter:
 
         Returns either a text string or AP2 objects (CartMandate, PaymentSuccess/Failure).
         """
-        async with httpx.AsyncClient() as httpx_client:
+        async with httpx.AsyncClient(follow_redirects=True) as httpx_client:
             try:
                 # Prepare A2A message payload
                 if isinstance(message, dict):

--- a/python/uagents-core/README.md
+++ b/python/uagents-core/README.md
@@ -1,3 +1,120 @@
 # uAgents-Core
 
-Core definitions and functionalities to build agent which can interact and integrate with Fetch.ai ecosystem and agent marketplace.
+Core definitions and functionalities for building agents that interact with the Fetch.ai ecosystem and Agentverse marketplace.
+
+## Installation
+
+```bash
+pip install uagents-core
+```
+
+## Quick Start
+
+### Register an Agent with Agentverse
+
+```python
+from uagents_core.utils.registration import (
+    register_in_agentverse,
+    AgentverseRegistrationRequest,
+)
+from uagents_core.registration import AgentverseConnectRequest
+from uagents_core.identity import Identity
+from uagents_core.config import AgentverseConfig
+
+# Create agent identity from a seed phrase
+identity = Identity.from_seed("my-agent-seed-phrase", 0)
+
+# Prepare registration request
+connect_request = AgentverseConnectRequest(
+    user_token="your-agentverse-api-key",
+    agent_type="proxy",
+    endpoint="https://your-agent-endpoint.com",
+)
+
+agent_details = AgentverseRegistrationRequest(
+    name="My Agent",
+    endpoint="https://your-agent-endpoint.com",
+    protocols=["your-protocol-digest"],
+    description="A helpful agent",
+    readme="Detailed description of what this agent does.",
+)
+
+# Register the agent (permanent, no refresh needed)
+success = register_in_agentverse(
+    request=connect_request,
+    identity=identity,
+    agent_details=agent_details,
+    agentverse_config=AgentverseConfig(),
+)
+```
+
+## Key Features
+
+### Permanent Registration
+
+Registrations via the v2 API are **permanent** - no need for periodic refresh:
+
+- Agentverse handles Almanac synchronization automatically
+- No 48-hour expiration like v1
+- Register once when agent is created
+
+### Agent Identity
+
+Create and manage agent identities:
+
+```python
+from uagents_core.identity import Identity
+
+# Create from seed (deterministic)
+identity = Identity.from_seed("my-seed-phrase", 0)
+
+# Get agent address
+print(identity.address)  # agent1q...
+
+# Sign messages
+signature = identity.sign(b"message")
+```
+
+### Configuration
+
+```python
+from uagents_core.config import AgentverseConfig
+
+config = AgentverseConfig()
+print(config.agents_api)    # https://agentverse.ai/v2/agents
+print(config.identity_api)  # https://agentverse.ai/v2/identity
+print(config.almanac_api)   # https://agentverse.ai/v1/almanac
+```
+
+## Available Functions
+
+### Registration
+
+| Function | Purpose |
+|----------|---------|
+| `register_in_agentverse()` | Register a single agent (recommended) |
+| `register_agent()` | Register with credentials object |
+| `register_chat_agent()` | Register agent with chat protocol |
+| `update_agent_status()` | Update agent active/inactive status |
+
+### Models
+
+| Model | Purpose |
+|-------|---------|
+| `RegistrationRequest` | Agent registration data |
+| `AgentProfile` | Agent profile (description, readme, avatar) |
+| `AgentverseConnectRequest` | Connection credentials |
+| `Identity` | Agent identity and signing |
+
+## Upgrading
+
+See [UPGRADING.md](../docs/UPGRADING.md) for migration guides between versions.
+
+## Related Packages
+
+- **[uagents](https://pypi.org/project/uagents/)** - Full agent framework with decorators and runtime
+- **[uagents-adapter](../uagents-adapter/)** - Adapters for LangChain, CrewAI, MCP
+
+## License
+
+Apache 2.0 - See [LICENSE](../../LICENSE) for details.

--- a/python/uagents-core/pyproject.toml
+++ b/python/uagents-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "uagents-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "Core components for agent based systems"
 authors = [
     { name = "Ed FitzGerald", email = "edward.fitzgerald@fetch.ai" },

--- a/python/uagents-core/uagents_core/utils/registration.py
+++ b/python/uagents-core/uagents_core/utils/registration.py
@@ -1,5 +1,47 @@
-"""
-This module provides methods to register your identity with the Fetch.ai services.
+"""Registration utilities for the Agentverse platform.
+
+This module provides functions to register agents with Agentverse, the Fetch.ai
+agent discovery and marketplace service. Registration makes your agent
+discoverable by other agents and sets up the webhook endpoint for receiving
+messages.
+
+Typical usage for a chat-capable agent::
+
+    from uagents_core.utils.registration import (
+        AgentverseRequestError,
+        RegistrationRequestCredentials,
+        register_chat_agent,
+    )
+
+    credentials = RegistrationRequestCredentials(
+        agent_seed_phrase="your-agent-seed-phrase",
+        agentverse_api_key="your-agentverse-api-key",
+    )
+
+    try:
+        register_chat_agent(
+            name="My Agent",
+            endpoint="https://my-server.com/webhook",
+            active=True,
+            credentials=credentials,
+            readme="# My Agent\\nHandles customer questions.",
+        )
+    except AgentverseRequestError as error:
+        print(f"Registration failed: {error}")
+        # Access the underlying network/HTTP exception:
+        print(f"Caused by: {error.from_exc}")
+
+Registration performs three steps:
+
+1. **Identity verification** -- proves ownership of the agent address via a
+   cryptographic challenge-response flow with the Agentverse identity API.
+2. **Agent details registration** -- creates or updates the agent's profile,
+   endpoint, protocols, and metadata on Agentverse.
+3. **Status activation** -- marks the agent as active in the Almanac so
+   Agentverse keeps the entry synchronized and discoverable.
+
+All HTTP failures are wrapped in :class:`AgentverseRequestError`, which
+preserves the original exception in its ``from_exc`` attribute for debugging.
 """
 
 import urllib.parse
@@ -33,12 +75,18 @@ logger = get_logger("uagents_core.utils.registration")
 
 
 class AgentverseRegistrationRequest(BaseModel):
-    """
-    A model containing all information for a user to register
-    their pre-existing agent to Agentverse.
+    """All information needed to register an agent with Agentverse.
+
+    This is the internal representation used by :func:`register_agent` and
+    :func:`register_chat_agent`. Most callers should use those functions
+    directly rather than constructing this model manually.
+
+    Raises:
+        ValueError: If ``endpoint`` is not a valid URL or any protocol
+            digest in ``protocols`` is malformed.
     """
 
-    name: str = Field(description="Agent name in Agentverse")
+    name: str = Field(description="Agent name in Agentverse.")
     endpoint: str = Field(
         description="Endpoint where the existing agent is accessible at."
     )
@@ -50,7 +98,7 @@ class AgentverseRegistrationRequest(BaseModel):
         description="Additional metadata about the agent (e.g. geolocation).",
     )
     type: AgentType = Field(
-        default="uagent", description="Agentverse registration type"
+        default="uagent", description="Agentverse registration type."
     )
     description: str | None = Field(
         default=None,
@@ -59,23 +107,24 @@ class AgentverseRegistrationRequest(BaseModel):
     readme: str | None = Field(default=None, description="Agent skills description.")
     avatar_url: str | None = Field(
         default=None,
-        description="Agent avatar url to be shown on its Agentverse profile.",
+        description="Agent avatar URL to be shown on its Agentverse profile.",
     )
     handle: str | None = Field(
         default=None,
         max_length=40,
         description="Agent's unique handle in Agentverse.",
     )
-    active: bool = Field(default=True, description="Set agent as active immediatly")
+    active: bool = Field(
+        default=True,
+        description="Set agent as active immediately after registration.",
+    )
 
     @model_validator(mode="after")
     def check_request(self) -> "AgentverseRegistrationRequest":
-        # check endpoint
         result = urllib.parse.urlparse(self.endpoint)
         if not all([result.scheme, result.netloc]):
             raise ValueError(f"Invalid endpoint provided: {self.endpoint}")
 
-        # check protocol digests
         for proto_digest in self.protocols:
             if not is_valid_protocol_digest(proto_digest):
                 raise ValueError(
@@ -85,18 +134,76 @@ class AgentverseRegistrationRequest(BaseModel):
 
 
 class RegistrationRequestCredentials(BaseModel):
+    """Credentials required to authenticate with the Agentverse API.
+
+    Attributes:
+        agentverse_api_key: An API key generated from the Agentverse dashboard
+            (https://agentverse.ai). This authenticates the request.
+        agent_seed_phrase: The secret seed phrase used to derive the agent's
+            cryptographic identity. This must match the seed used when the
+            agent was first created.
+        team: Optional team identifier. When provided, the agent is registered
+            under this team in Agentverse.
+    """
+
     agentverse_api_key: str = Field(
-        description="Agentverse API key generated by the owner of the agent"
+        description="Agentverse API key generated by the owner of the agent."
     )
     agent_seed_phrase: str = Field(
-        description="The secret seed phrase used to create the agent identity"
+        description="The secret seed phrase used to create the agent identity."
     )
     team: str | None = Field(
-        default=None, description="The team the agent belongs to in Agentverse"
+        default=None, description="The team the agent belongs to in Agentverse."
     )
 
 
 class AgentverseRequestError(Exception):
+    """Raised when an Agentverse API request fails.
+
+    This exception wraps all HTTP and network errors that occur during
+    registration, identity verification, or status updates. The human-readable
+    message describes what went wrong, while ``from_exc`` preserves the
+    original exception for debugging.
+
+    Attributes:
+        from_exc: The original exception that caused this error. Common types
+            include ``requests.ConnectionError`` (network unreachable),
+            ``requests.Timeout`` (request timed out),
+            ``requests.HTTPError`` (non-2xx status code), and
+            ``requests.RequestException`` (other request failures).
+
+    Common error messages and their meaning:
+
+    - ``"Connection error ..."`` -- Could not reach the Agentverse API. Check
+      your network connection and the configured base URL.
+    - ``"Operation timed out."`` -- The request exceeded the timeout
+      (default: 10 seconds). The Agentverse API may be under heavy load.
+    - ``"HTTP error: 401 ..."`` -- Invalid or expired API key. Generate a new
+      key from the Agentverse dashboard.
+    - ``"HTTP error: 406 ..."`` -- The request was not acceptable. This
+      typically means the agent data is malformed or missing required fields.
+    - ``"HTTP error: 409 ..."`` -- Conflict. The agent address or handle is
+      already registered by a different account.
+    - ``"Unexpected server error."`` -- HTTP 500 from Agentverse. Retry after
+      a short delay. If persistent, check the Agentverse status page.
+    - ``"failed to request proof-of-ownership challenge. ..."`` -- The
+      identity verification step failed. This usually means the API key
+      does not have permission to register this agent address.
+
+    Example::
+
+        try:
+            register_chat_agent(...)
+        except AgentverseRequestError as error:
+            print(f"Registration failed: {error}")
+
+            # Inspect the underlying cause
+            if isinstance(error.from_exc, requests.Timeout):
+                print("Consider increasing the timeout or retrying.")
+            elif isinstance(error.from_exc, requests.HTTPError):
+                print(f"HTTP status: {error.from_exc.response.status_code}")
+    """
+
     def __init__(self, *args, from_exc: Exception):
         self.from_exc = from_exc
         super().__init__(*args)
@@ -177,15 +284,15 @@ def _register_in_agentverse(
     agentverse_config: AgentverseConfig | None = None,
     timeout: int = DEFAULT_REQUEST_TIMEOUT,
 ):
-    """
-    Register an agent in Agentverse and update its details if provided.
+    """Register an agent in Agentverse (internal implementation).
 
-    Args:
-        request (AgentverseConnectRequest): The request containing the agent details.
-        identity (Identity): The identity of the agent.
-        agent_details (AgentverseRegistrationRequest): The agent details to update.
-        agentverse_config (AgentverseConfig | None): The configuration for the agentverse API
-        timeout (int): The timeout for the requests
+    Performs identity verification (if the agent is new) and then registers
+    or updates the agent's details. This is the core implementation used by
+    :func:`register_in_agentverse` and :func:`register_agent`.
+
+    Raises:
+        AgentverseRequestError: If any API call fails (identity challenge,
+            identity proof submission, or agent details registration).
     """
     agentverse_config = agentverse_config or AgentverseConfig()
     agents_api = agentverse_config.agents_api
@@ -293,15 +400,28 @@ def register_in_agentverse(
     agentverse_config: AgentverseConfig | None = None,
     timeout: int = DEFAULT_REQUEST_TIMEOUT,
 ) -> bool:
-    """
-    Register an agent in Agentverse and update its details if provided.
+    """Register an agent in Agentverse (error-safe wrapper).
+
+    This is a convenience wrapper around :func:`_register_in_agentverse`
+    that catches :class:`AgentverseRequestError` and returns ``False``
+    instead of raising. Use this when you want simple boolean success/failure
+    semantics without handling exceptions.
+
+    For error details, use :func:`register_agent` or
+    :func:`register_chat_agent` instead, which raise
+    :class:`AgentverseRequestError` with diagnostic information.
 
     Args:
-        request (AgentverseConnectRequest): The request containing the agent details.
-        identity (Identity): The identity of the agent.
-        agent_details (AgentverseRegistrationRequest): The agent details to update.
-        agentverse_config (AgentverseConfig | None): The configuration for the agentverse API
-        timeout (int): The timeout for the requests
+        request: Connection details including the API token and endpoint.
+        identity: The cryptographic identity of the agent.
+        agent_details: Agent profile data to register.
+        agentverse_config: Custom API configuration. Defaults to the
+            standard Agentverse production endpoint.
+        timeout: HTTP request timeout in seconds. Defaults to 10.
+
+    Returns:
+        ``True`` if registration succeeded, ``False`` if any API call failed.
+        On failure, the error is logged but not raised.
     """
     try:
         _register_in_agentverse(
@@ -319,12 +439,14 @@ def register_in_agentverse(
 
 
 def _update_agent_status(active: bool, identity: Identity):
-    """
-    Update the agent's active/inactive status in the Almanac API.
+    """Update the agent's active/inactive status in the Almanac API.
 
-    Args:
-        active (bool): The status of the agent.
-        identity (Identity): The identity of the agent.
+    Active agents are kept synchronized by Agentverse and remain
+    discoverable. Inactive agents are still registered but will not
+    appear in search results.
+
+    Raises:
+        AgentverseRequestError: If the status update API call fails.
     """
     almanac_api = AgentverseConfig().url + DEFAULT_ALMANAC_API_PATH
 
@@ -345,12 +467,19 @@ def _update_agent_status(active: bool, identity: Identity):
 
 
 def update_agent_status(active: bool, identity: Identity) -> bool:
-    """
-    Update the agent's active/inactive status in the Almanac API.
+    """Update the agent's active/inactive status (error-safe wrapper).
+
+    This is a convenience wrapper that catches :class:`AgentverseRequestError`
+    and returns ``False`` instead of raising.
 
     Args:
-        active (bool): The status of the agent.
-        identity (Identity): The identity of the agent.
+        active: ``True`` to mark the agent as active (discoverable),
+            ``False`` to mark it as inactive.
+        identity: The cryptographic identity of the agent.
+
+    Returns:
+        ``True`` if the status update succeeded, ``False`` otherwise.
+        On failure, the error is logged but not raised.
     """
     try:
         _update_agent_status(active, identity)
@@ -366,14 +495,35 @@ def register_agent(
     agentverse_config: AgentverseConfig,
     credentials: RegistrationRequestCredentials,
 ) -> bool:
-    """
-    Register an agent in Agentverse and optionally set it as active.
+    """Register an agent in Agentverse and optionally set it as active.
+
+    This is the primary registration function. It derives the agent's
+    cryptographic identity from the seed phrase, verifies ownership with
+    Agentverse, registers the agent details, and (if ``active=True`` in
+    the registration request) sets the agent status to active.
+
+    For chat-capable agents, prefer :func:`register_chat_agent` which
+    automatically includes the chat protocol digest.
+
+    Args:
+        agent_registration: The agent details to register (name, endpoint,
+            protocols, metadata, etc.).
+        agentverse_config: API configuration (base URL, HTTP prefix).
+        credentials: Authentication credentials (API key, seed phrase,
+            and optional team).
 
     Returns:
-        True if registration (and activation, if requested) succeeded.
+        ``True`` if registration (and activation, if requested) succeeded.
 
     Raises:
-        AgentverseRequestError: If registration or activation fails.
+        AgentverseRequestError: If any step of the registration fails.
+            Common causes include invalid API key (HTTP 401), malformed
+            request data (HTTP 406), address conflict (HTTP 409), server
+            errors (HTTP 500), network timeouts, or connection failures.
+            The original exception is available via ``error.from_exc``.
+        ValueError: If the endpoint URL or protocol digests in
+            ``agent_registration`` are malformed (raised during model
+            validation, before any API calls are made).
     """
     identity = Identity.from_seed(credentials.agent_seed_phrase, 0)
     connect_request = AgentverseConnectRequest(
@@ -411,14 +561,79 @@ def register_chat_agent(
     metadata: AgentMetadata | dict[str, str | list[str] | dict[str, str]] | None = None,
     agentverse_config: AgentverseConfig | None = None,
 ) -> bool:
-    """
-    Register a chat-capable agent in Agentverse.
+    """Register a chat-capable agent in Agentverse.
+
+    This is the recommended entry point for registering agents that support
+    the standard chat protocol. It automatically includes the chat protocol
+    digest so the agent is discoverable for chat-based interactions.
+
+    The function performs three steps:
+
+    1. **Identity verification** -- If this is a new agent, proves ownership
+       via a cryptographic challenge signed with the agent's seed phrase.
+    2. **Agent details registration** -- Creates or updates the agent's name,
+       endpoint, readme, avatar, and metadata on Agentverse.
+    3. **Status activation** -- If ``active=True``, marks the agent as active
+       in the Almanac so it remains discoverable.
+
+    Args:
+        name: Display name for the agent on Agentverse (max 80 characters
+            recommended).
+        endpoint: The publicly accessible webhook URL where the agent
+            receives messages. Must include scheme (``https://``).
+        active: Whether to set the agent as active immediately after
+            registration. Active agents are discoverable and kept
+            synchronized by Agentverse.
+        credentials: Authentication credentials. See
+            :class:`RegistrationRequestCredentials`.
+        description: Short description shown on the agent's Agentverse
+            profile page.
+        readme: Longer markdown description of the agent's capabilities.
+            This is displayed on the agent's detail page in Agentverse.
+        avatar_url: URL to the agent's avatar image.
+        metadata: Additional metadata such as categories, tags, geolocation,
+            contact details, and visibility (``is_public``). Can be a dict
+            or an :class:`AgentMetadata` instance.
+        agentverse_config: Custom API configuration. Defaults to the
+            standard Agentverse production endpoint (``agentverse.ai``).
 
     Returns:
-        True if registration succeeded.
+        ``True`` if registration succeeded.
 
     Raises:
-        AgentverseRequestError: If registration or activation fails.
+        AgentverseRequestError: If any step of the registration or
+            activation fails. See :class:`AgentverseRequestError` for
+            common error messages and their meaning.
+        ValueError: If ``endpoint`` is not a valid URL.
+
+    Example::
+
+        from uagents_core.utils.registration import (
+            AgentverseRequestError,
+            RegistrationRequestCredentials,
+            register_chat_agent,
+        )
+
+        credentials = RegistrationRequestCredentials(
+            agent_seed_phrase="my-secret-seed",
+            agentverse_api_key="av-key-...",
+        )
+
+        try:
+            register_chat_agent(
+                name="Customer Support Agent",
+                endpoint="https://my-server.com/agent/webhook",
+                active=True,
+                credentials=credentials,
+                readme="# Customer Support\\nAnswers product questions.",
+                metadata={
+                    "categories": ["support"],
+                    "is_public": "True",
+                },
+            )
+            print("Agent registered successfully!")
+        except AgentverseRequestError as error:
+            print(f"Registration failed: {error}")
     """
     chat_protocol = [
         ProtocolSpecification.compute_digest(chat_protocol_spec.manifest())
@@ -450,18 +665,24 @@ def register_batch_in_agentverse(
     agentverse_config: AgentverseConfig | None = None,
     timeout: int = DEFAULT_REQUEST_TIMEOUT,
 ) -> bool:
-    """
-    Register multiple agents in Agentverse using the batch endpoint.
+    """Register multiple agents in a single batch request (error-safe).
+
+    .. deprecated::
+        Prefer individual :func:`register_chat_agent` calls. Batch
+        registration does not include identity verification or status
+        activation.
 
     Args:
-        batch_request (BatchRegistrationRequest): The batch registration request containing
-            a list of agents to register.
-        user_token (str): The user's authentication token for Agentverse.
-        agentverse_config (AgentverseConfig | None): The configuration for the agentverse API.
-        timeout (int): The timeout for the request.
+        batch_request: The batch registration request containing a list
+            of agents to register.
+        user_token: The user's Agentverse API key.
+        agentverse_config: Custom API configuration. Defaults to the
+            standard Agentverse production endpoint.
+        timeout: HTTP request timeout in seconds. Defaults to 10.
 
     Returns:
-        bool: True if the batch registration was successful, False otherwise.
+        ``True`` if the batch registration succeeded, ``False`` otherwise.
+        On failure, the error is logged but not raised.
     """
     agentverse_config = agentverse_config or AgentverseConfig()
     agents_api = agentverse_config.agents_api


### PR DESCRIPTION
## Summary

`httpx.AsyncClient` defaults `follow_redirects` to `False`, causing 308 Permanent Redirect responses from Agentverse and A2A endpoints to be returned as errors instead of being followed. This affects agent discovery, health checks, message sending, and LLM routing in the A2A outbound adapter.

This is a companion fix to [flockx-official/platform#11263](https://github.com/flockx-official/platform/pull/11263), which addresses the same issue in the platform codebase.

## Notable changes

- **`a2a_outbound/adapter.py`** - 4 `httpx.AsyncClient` instantiations now include `follow_redirects=True`:
  - `_send_to_a2a_agent` (message sending)
  - `_discover_and_health_check_agents` (agent card fetching)
  - `route_to_llm` (LLM API routing)
  - Agent card well-known endpoint fetching

## How tested

- Code review of all `httpx.AsyncClient` instantiations in the adapter
- Confirmed the change is additive - no behavioral change for endpoints that do not redirect

## Risks / breaking changes

None. Adding `follow_redirects=True` makes httpx behave like `requests` and `aiohttp` do by default.