### PR TITLE
Fix #865: RFC: Security middleware layer for uAgent message handlers ...

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -947,6 +947,7 @@ class Agent(Sink):
         model: type[Model],
         replies: type[Model] | set[type[Model]] | None = None,
         allow_unverified: bool = False,
+        allowed_senders: set[str] | None = None,
     ):
         """
         Decorator to register an message handler for the provided message model.
@@ -955,11 +956,13 @@ class Agent(Sink):
             model (type[Model]): The message model.
             replies (type[Model] | set[type[Model]] | None): Optional reply models.
             allow_unverified (bool): Allow unverified messages.
+            allowed_senders (set[str] | None): Optional set of agent addresses permitted to
+                trigger this handler. Messages from other senders are silently dropped.
 
         Returns:
             Callable: The decorator function for registering message handlers.
         """
-        return self._protocol.on_message(model, replies, allow_unverified)
+        return self._protocol.on_message(model, replies, allow_unverified, allowed_senders)
 
     def on_event(self, event_type: str):
         """

--- a/python/src/uagents/protocol.py
+++ b/python/src/uagents/protocol.py
@@ -310,6 +310,7 @@ class Protocol:
         model: type[Model],
         replies: type[Model] | set[type[Model]] | None = None,
         allow_unverified: bool = False,
+        allowed_senders: set[str] | None = None,
     ) -> Callable:
         """
         Decorator to register a message handler for the protocol.
@@ -318,6 +319,8 @@ class Protocol:
             model (type[Model]): The message model type.
             replies (type[Model] | set[type[Model]] | None): The associated reply types.
             allow_unverified (bool, optional): Whether to allow unverified messages.
+            allowed_senders (set[str] | None): Optional set of agent addresses permitted to
+                trigger this handler. Messages from other senders are silently dropped.
 
         Returns:
             Callable: The decorator to register the message handler.
@@ -341,7 +344,7 @@ class Protocol:
             def handler(*args, **kwargs):
                 return func(*args, **kwargs)
 
-            self._add_message_handler(model, func, replies, allow_unverified)
+            self._add_message_handler(model, func, replies, allow_unverified, allowed_senders)
 
             return handler
 
@@ -353,6 +356,7 @@ class Protocol:
         func: MessageCallback,
         replies: type[Model] | set[type[Model]] | None,
         allow_unverified: bool = False,
+        allowed_senders: set[str] | None = None,
     ):
         """
         Add a message handler to the protocol.
@@ -362,8 +366,24 @@ class Protocol:
             func (MessageCallback): The message handler function.
             replies (type[Model] | set[type[Model]] | None): The associated reply types.
             allow_unverified (bool, optional): Whether to allow unverified messages.
+            allowed_senders (set[str] | None): Optional set of agent addresses permitted to
+                trigger this handler. Messages from other senders are silently dropped.
         """
         model_digest = Model.build_schema_digest(model)
+
+        if allowed_senders is not None:
+            _allowed = frozenset(allowed_senders)
+            _orig_func = func
+
+            async def _guarded(ctx, sender, msg):
+                if sender not in _allowed:
+                    logger.warning(
+                        f"Unauthorized sender '{sender}' for handler of '{model.__name__}'"
+                    )
+                    return
+                return await _orig_func(ctx, sender, msg)
+
+            func = _guarded
 
         # update the model database
         self._models[model_digest] = model

--- a/python/tests/test_protocol.py
+++ b/python/tests/test_protocol.py
@@ -81,3 +81,34 @@ class TestAgent(unittest.TestCase):
         self.assertEqual(len(models), 2)
         self.assertEqual(len(unsigned_msg_handlers), 1)
         self.assertEqual(len(signed_msg_handlers), 1)
+
+    def test_protocol_allowed_senders_registered(self):
+        proto = Protocol(name="allowed_test", version="1.0.0")
+        allowed = {"agent1abc", "agent2abc"}
+
+        @proto.on_message(Message, allowed_senders=allowed)
+        async def _(_ctx, _sender, _msg):
+            pass
+
+        digest = Model.build_schema_digest(Message)
+        self.assertIn(digest, proto._signed_message_handlers)
+
+    def test_protocol_allowed_senders_blocks_unauthorized(self):
+        import asyncio
+
+        proto = Protocol(name="allowed_block_test", version="1.0.0")
+        allowed = {"agent_authorized"}
+        called_with = []
+
+        @proto.on_message(Message, allowed_senders=allowed)
+        async def _(_ctx, _sender, _msg):
+            called_with.append(_sender)
+
+        digest = Model.build_schema_digest(Message)
+        handler = proto._signed_message_handlers[digest]
+
+        asyncio.get_event_loop().run_until_complete(handler(None, "agent_unauthorized", None))
+        self.assertEqual(called_with, [])
+
+        asyncio.get_event_loop().run_until_complete(handler(None, "agent_authorized", None))
+        self.assertEqual(called_with, ["agent_authorized"])


### PR DESCRIPTION
Closes #865

## Proposed Changes

Adds an `allowed_senders` parameter to `Protocol.on_message` (and the corresponding `Agent.on_message` wrapper) that restricts handler execution to a declared set of agent addresses.

**`python/src/uagents/protocol.py`**
- `Protocol.on_message` and `Protocol._add_message_handler` accept a new `allowed_senders: set[str] | None` parameter.
- When `allowed_senders` is provided, `_add_message_handler` wraps the original callback in `_guarded`, an async closure that checks `sender` against a `frozenset` of permitted addresses. Unauthorized senders produce a `logger.warning` and return without invoking the handler.

**`python/src/uagents/agent.py`**
- `Agent.on_message` passes the new `allowed_senders` argument through to `self._protocol.on_message`.

**`python/tests/test_protocol.py`**
- `test_protocol_allowed_senders_registered`: confirms the handler digest is stored in `_signed_message_handlers` when `allowed_senders` is set.
- `test_protocol_allowed_senders_blocks_unauthorized`: exercises the `_guarded` wrapper end-to-end — verifies an unauthorized sender is dropped and an authorized sender reaches the callback.

## Linked Issues

Addresses the authorization gap described in #865: any signed message from any registered agent could trigger any handler regardless of whether the receiving agent should accept commands from that sender.

## Types of changes

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

This is a minimal, in-framework authorization primitive that doesn't require an external policy gateway. It operates at the handler registration site, so the allow-list is co-located with the handler definition and remains visible in code review. The `frozenset` conversion in `_add_message_handler` ensures the provided set is not mutated after registration.

The `_guarded` wrapper only applies when `allowed_senders is not None`; omitting the parameter preserves existing behaviour exactly. No existing handler registration paths are affected.

This approach is intentionally narrower in scope than the full SINT middleware proposed in #865 — it addresses the most common case (static allow-lists known at registration time) without introducing a runtime policy dependency. Dynamic or tier-based authorization (T0–T3 approval flows, rate limiting, CSML drift detection) remains out of scope for this PR and would require a separate middleware hook point in the dispatch layer.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*