### PR TITLE
fix(uagents): handle intermediate responses in send_and_receive

### DIFF
--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -5,7 +5,7 @@ import logging
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from time import time
+from time import monotonic, time
 from typing import TYPE_CHECKING, Any
 
 import requests
@@ -630,47 +630,89 @@ class InternalContext(Context):
             )
             return None, msg_status
 
+        response_types: set[type[Model]] = (
+            {response_type} if isinstance(response_type, type) else response_type
+        )
         response_msg: MsgInfo | None = await dispatcher.wait_for_response(
             self.agent.address, parsed_address, self._session, timeout
         )
 
-        if response_msg is None:
-            log(self.logger, logging.ERROR, "Timeout waiting for response")
-            return None, MsgStatus(
-                status=DeliveryStatus.FAILED,
-                detail="Timeout waiting for response",
-                destination=destination,
-                endpoint="",
-                session=self._session,
-            )
-
-        response_types: set[type[Model]] = (
-            {response_type} if isinstance(response_type, type) else response_type
-        )
-
+        response_type_digests = {
+            Model.build_schema_digest(r_type): r_type for r_type in response_types
+        }
+        deadline = monotonic() + timeout
         response: Model | None = None
-        for r_type in response_types:
-            if response_msg.schema_digest == Model.build_schema_digest(r_type):
+        saw_unexpected_response = False
+
+        while True:
+            if response_msg is None:
+                dispatcher.cancel_pending_response(
+                    self.agent.address, parsed_address, self._session
+                )
+                if saw_unexpected_response:
+                    log(
+                        logger=self.logger,
+                        level=logging.ERROR,
+                        message="Timed out after receiving only unexpected response types",
+                    )
+                    return None, MsgStatus(
+                        status=DeliveryStatus.FAILED,
+                        detail="Received unexpected response type",
+                        destination=destination,
+                        endpoint="",
+                        session=self._session,
+                    )
+
+                log(self.logger, logging.ERROR, "Timeout waiting for response")
+                return None, MsgStatus(
+                    status=DeliveryStatus.FAILED,
+                    detail="Timeout waiting for response",
+                    destination=destination,
+                    endpoint="",
+                    session=self._session,
+                )
+
+            response_cls = response_type_digests.get(response_msg.schema_digest)
+            if response_cls is not None:
                 try:
-                    response = r_type.parse_raw(response_msg.message)
+                    response = response_cls.parse_raw(response_msg.message)
                     break
                 except ValidationError:
                     pass
 
-        if response is None:
+            remaining_timeout = deadline - monotonic()
+            if remaining_timeout <= 0:
+                log(
+                    logger=self.logger,
+                    level=logging.ERROR,
+                    message=f"Received unexpected response before timeout: {response_msg}",
+                )
+                dispatcher.cancel_pending_response(
+                    self.agent.address, parsed_address, self._session
+                )
+                msg_status = MsgStatus(
+                    status=DeliveryStatus.FAILED,
+                    detail="Received unexpected response type",
+                    destination=destination,
+                    endpoint="",
+                    session=self._session,
+                )
+                return None, msg_status
+
             log(
                 logger=self.logger,
-                level=logging.ERROR,
-                message=f"Received unexpected response: {response_msg}",
+                level=logging.WARNING,
+                message=f"Ignoring unexpected response while waiting for {response_types}: {response_msg}",
             )
-            msg_status = MsgStatus(
-                status=DeliveryStatus.FAILED,
-                detail="Received unexpected response type",
-                destination=destination,
-                endpoint="",
-                session=self._session,
+            saw_unexpected_response = True
+            response_msg = await dispatcher.wait_for_response(
+                self.agent.address,
+                parsed_address,
+                self._session,
+                remaining_timeout,
             )
 
+        dispatcher.cancel_pending_response(self.agent.address, parsed_address, self._session)
         return response, msg_status
 
     async def send_wallet_message(

--- a/python/src/uagents/dispatch.py
+++ b/python/src/uagents/dispatch.py
@@ -1,6 +1,6 @@
 import asyncio
 from abc import ABC, abstractmethod
-from asyncio import Future
+from asyncio import Future, Queue
 from typing import Any
 from uuid import UUID
 
@@ -36,21 +36,20 @@ class Dispatcher:
 
     def __init__(self):
         self._sinks: dict[str, set[Sink]] = {}
-        self._pending_responses: dict[PendingResponseKey, Future[MsgInfo]] = {}
+        self._pending_responses: dict[PendingResponseKey, Queue[MsgInfo]] = {}
 
     @property
     def sinks(self) -> dict[str, set[Sink]]:
         return self._sinks
 
     @property
-    def pending_responses(self) -> dict[PendingResponseKey, Future[MsgInfo]]:
+    def pending_responses(self) -> dict[PendingResponseKey, Queue[MsgInfo]]:
         return self._pending_responses
 
     async def register_pending_response(
         self, sender: str, destination: str, session: UUID
     ):
-        loop = asyncio.get_running_loop()
-        self._pending_responses[(sender, destination, session)] = loop.create_future()
+        self._pending_responses[(sender, destination, session)] = asyncio.Queue()
 
     def cancel_pending_response(self, sender: str, destination: str, session: UUID):
         key: tuple[str, str, UUID] = (sender, destination, session)
@@ -62,15 +61,12 @@ class Dispatcher:
     ) -> MsgInfo | None:
         key: tuple[str, str, UUID] = (sender, destination, session)
         try:
-            response = await asyncio.wait_for(self._pending_responses[key], timeout)
+            response = await asyncio.wait_for(self._pending_responses[key].get(), timeout)
         except asyncio.TimeoutError:
             response = None
         except KeyError:
             # Key was removed before wait_for completed
             response = None
-        finally:
-            # Safe deletion - only delete if key exists
-            self._pending_responses.pop(key, None)
         return response
 
     def dispatch_pending_response(
@@ -84,7 +80,7 @@ class Dispatcher:
         key = (destination, sender, session)
         response = MsgInfo(message=message, sender=sender, schema_digest=schema_digest)
         if key in self._pending_responses:
-            self._pending_responses[key].set_result(response)
+            self._pending_responses[key].put_nowait(response)
             return True
         return False
 

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -35,6 +35,10 @@ class Response(Model):
     text: str
 
 
+class Acknowledgement(Model):
+    status: str
+
+
 endpoints = ["http://localhost:8000"]
 
 incoming = Incoming(text="hello")
@@ -598,6 +602,41 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         # Assertions
         self.assertEqual(status, exp_msg_status)
         self.assertEqual(len(dispatcher.pending_responses), 0)
+
+    async def test_send_and_receive_async_ignores_intermediate_wrong_response_type(self):
+        context = self.alice._build_context()
+
+        proto = Protocol()
+
+        @proto.on_message(model=Message)
+        async def _(ctx, sender, msg):
+            await ctx.send(sender, Acknowledgement(status="accepted"))
+            await asyncio.sleep(0.1)
+            await ctx.send(sender, Incoming(text="hello"))
+
+        temp_agent = Agent(name="temp", seed="temp recovery phrase")
+        temp_agent.include(proto)
+        self.loop.create_task(temp_agent._process_message_queue())
+        self.loop.create_task(temp_agent._dispenser.run())
+
+        try:
+            response, status = await context.send_and_receive(
+                temp_agent.address, msg, response_type=Incoming, timeout=5
+            )
+
+            exp_msg_status = MsgStatus(
+                status=DeliveryStatus.DELIVERED,
+                detail="Message dispatched locally",
+                destination=temp_agent.address,
+                endpoint="",
+                session=context.session,
+            )
+
+            self.assertEqual(status, exp_msg_status)
+            self.assertEqual(response, incoming)
+            self.assertEqual(len(dispatcher.pending_responses), 0)
+        finally:
+            dispatcher.unregister(temp_agent.address, temp_agent)
 
 
 class TestMessageHistory(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- keep pending responses in arrival order instead of treating the first response as terminal
- let `ctx.send_and_receive()` ignore intermediate unexpected response types while continuing to wait within the same timeout window
- preserve the existing failure contract when only unexpected response types arrive
- add a regression test for the acknowledgement-then-message pattern

## Why
This fixes issue #798, where `ctx.send_and_receive()` can fail if an acknowledgement or other unexpected message arrives before the expected response type.

## Testing
- `python -m pytest -q python/tests/test_context.py -k send_and_receive`
- `python -m compileall python/src/uagents python/tests/test_context.py`

Closes #798