### PR TITLE
fix(uagents): ignore unexpected response types on send_and_receive

### DIFF
--- a/python/docs/api/uagents/communication.md
+++ b/python/docs/api/uagents/communication.md
@@ -35,7 +35,7 @@ Add an envelope to the dispenser.
 
 
 
-#### run[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L80)
+#### run[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L81)
 ```python
 async def run() -> None
 ```
@@ -44,7 +44,7 @@ Run the dispenser routine.
 
 
 
-#### dispatch_local_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L102)
+#### dispatch_local_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L103)
 ```python
 async def dispatch_local_message(sender: str, destination: str,
                                  schema_digest: str, message: JsonStr,
@@ -55,7 +55,7 @@ Process a message locally.
 
 
 
-#### send_exchange_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L126)
+#### send_exchange_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L127)
 ```python
 async def send_exchange_envelope(envelope: Envelope,
                                  endpoints: list[str],
@@ -77,7 +77,7 @@ Method to send an exchange envelope.
 
 
 
-#### dispatch_sync_response_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L200)
+#### dispatch_sync_response_envelope[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L201)
 ```python
 async def dispatch_sync_response_envelope(
         env: Envelope, endpoint: str) -> MsgStatus | Envelope
@@ -87,7 +87,7 @@ Dispatch a synchronous response envelope locally.
 
 
 
-#### send_message_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L223)
+#### send_message_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L224)
 ```python
 async def send_message_raw(
         destination: str,
@@ -123,7 +123,7 @@ Standalone function to send a message to an agent.
 
 
 
-#### send_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L302)
+#### send_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L303)
 ```python
 async def send_message(
         destination: str,
@@ -157,7 +157,7 @@ Standalone function to send a message to an agent.
 
 
 
-#### send_sync_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L341)
+#### send_sync_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L342)
 ```python
 async def send_sync_message(
     destination: str,
@@ -191,7 +191,7 @@ Standalone function to send a synchronous message to an agent.
 
 
 
-#### enclose_response[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L378)
+#### enclose_response[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L379)
 ```python
 def enclose_response(message: Model,
                      sender: str,
@@ -215,7 +215,7 @@ Enclose a response message within an envelope.
 
 
 
-#### enclose_response_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L403)
+#### enclose_response_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/communication.py#L404)
 ```python
 def enclose_response_raw(json_message: JsonStr,
                          schema_digest: str,

--- a/python/docs/api/uagents/context.md
+++ b/python/docs/api/uagents/context.md
@@ -6,7 +6,7 @@ Agent Context and Message Handling
 
 
 
-## Context Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L37)
+## Context Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L36)
 
 ```python
 class Context(ABC)
@@ -34,7 +34,7 @@ session (uuid.UUID): The session UUID associated with the context.
 
 
 
-#### agent[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L59)
+#### agent[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L58)
 ```python
 @property
 @abstractmethod
@@ -49,7 +49,7 @@ Get the agent representation associated with the context.
 
 
 
-#### storage[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L70)
+#### storage[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L69)
 ```python
 @property
 @abstractmethod
@@ -64,7 +64,7 @@ Get the key-value store associated with the context.
 
 
 
-#### ledger[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L81)
+#### ledger[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L80)
 ```python
 @property
 @abstractmethod
@@ -79,7 +79,7 @@ Get the ledger client associated with the context.
 
 
 
-#### logger[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L92)
+#### logger[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L91)
 ```python
 @property
 @abstractmethod
@@ -94,7 +94,7 @@ Get the logger instance associated with the context.
 
 
 
-#### session[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L103)
+#### session[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L102)
 ```python
 @property
 @abstractmethod
@@ -109,7 +109,7 @@ Get the session UUID associated with the context.
 
 
 
-#### get_agents_by_protocol[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L114)
+#### get_agents_by_protocol[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L113)
 ```python
 @abstractmethod
 def get_agents_by_protocol(protocol_digest: str,
@@ -135,7 +135,7 @@ limited to a specified number of addresses.
 
 
 
-#### broadcast[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L136)
+#### broadcast[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L135)
 ```python
 @abstractmethod
 async def broadcast(
@@ -165,7 +165,7 @@ The schema digest of the message is used for verification.
 
 
 
-#### session_history[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L161)
+#### session_history[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L160)
 ```python
 @abstractmethod
 def session_history() -> list[EnvelopeHistoryEntry] | None
@@ -179,7 +179,7 @@ Get the message history associated with the context session.
 
 
 
-#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L171)
+#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L170)
 ```python
 @abstractmethod
 async def send(destination: str,
@@ -202,7 +202,7 @@ Send a message to the specified destination.
 
 
 
-#### send_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L191)
+#### send_raw[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L190)
 ```python
 @abstractmethod
 async def send_raw(
@@ -237,7 +237,7 @@ message schema digest are sent separately.
 
 
 
-#### send_and_receive[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L222)
+#### send_and_receive[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L221)
 ```python
 @abstractmethod
 async def send_and_receive(
@@ -266,7 +266,7 @@ Send a message to the specified destination and receive a response.
 
 
 
-#### send_wallet_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L246)
+#### send_wallet_message[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L245)
 ```python
 @abstractmethod
 async def send_wallet_message(destination: str, text: str, msg_type: int = 1)
@@ -287,7 +287,7 @@ Send a message to the wallet of the specified destination.
 
 
 
-## InternalContext Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L267)
+## InternalContext Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L266)
 
 ```python
 class InternalContext(Context)
@@ -297,7 +297,7 @@ Represents the agent internal context for proactive behaviour.
 
 
 
-#### session[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L311)
+#### session[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L310)
 ```python
 @property
 def session() -> uuid.UUID
@@ -311,7 +311,7 @@ Get the session UUID associated with the context.
 
 
 
-#### outbound_messages[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L321)
+#### outbound_messages[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L320)
 ```python
 @property
 def outbound_messages() -> dict[str, list[tuple[JsonStr, str]]]
@@ -325,7 +325,7 @@ Get the dictionary of outbound messages associated with the context.
 
 
 
-#### session_history[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L331)
+#### session_history[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L330)
 ```python
 def session_history() -> list[EnvelopeHistoryEntry] | None
 ```
@@ -338,7 +338,7 @@ Get the message history associated with the context session.
 
 
 
-#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L417)
+#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L416)
 ```python
 async def send(destination: str,
                message: Model,
@@ -352,7 +352,7 @@ contexts, like 'replies', 'message_received', or 'protocol'.
 
 
 
-#### send_and_receive[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L593)
+#### send_and_receive[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L594)
 ```python
 async def send_and_receive(
     destination: str,
@@ -380,7 +380,7 @@ Send a message to the specified destination and receive a response.
 
 
 
-## ExternalContext Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L692)
+## ExternalContext Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L675)
 
 ```python
 class ExternalContext(InternalContext)
@@ -400,7 +400,7 @@ Represents the reactive context in which messages are handled and processed.
 
 
 
-#### __init__[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L706)
+#### __init__[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L689)
 ```python
 def __init__(message_received: MsgInfo,
              queries: dict[str, asyncio.Future] | None = None,
@@ -422,7 +422,7 @@ Initialize the ExternalContext instance and attributes needed from the InternalC
 
 
 
-#### validate_replies[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L731)
+#### validate_replies[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L714)
 ```python
 def validate_replies(message_type: type[Model]) -> None
 ```
@@ -435,7 +435,7 @@ If the context specifies replies, ensure that a valid reply was sent.
 
 
 
-#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L772)
+#### send[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/context.py#L755)
 ```python
 async def send(destination: str,
                message: Model,

--- a/python/docs/api/uagents/dispatch.md
+++ b/python/docs/api/uagents/dispatch.md
@@ -4,7 +4,25 @@
 
 
 
-## Sink Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/dispatch.py#L14)
+## PendingResponse Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/dispatch.py#L15)
+
+```python
+@dataclass
+class PendingResponse()
+```
+
+
+
+#### accepts[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/dispatch.py#L20)
+```python
+def accepts(schema_digest: str) -> bool
+```
+
+Whether an incoming message should resolve this response slot.
+
+
+
+## Sink Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/dispatch.py#L29)
 
 ```python
 class Sink(ABC)
@@ -14,7 +32,7 @@ Abstract base class for sinks that handle messages.
 
 
 
-## Dispatcher Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/dispatch.py#L32)
+## Dispatcher Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/dispatch.py#L47)
 
 ```python
 class Dispatcher()

--- a/python/docs/api/uagents/registration.md
+++ b/python/docs/api/uagents/registration.md
@@ -39,7 +39,7 @@ Send a POST request to the Almanac API.
 
 
 
-## LedgerBasedRegistrationPolicy Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/registration.py#L220)
+## LedgerBasedRegistrationPolicy Objects[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/registration.py#L224)
 
 ```python
 class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy)
@@ -47,7 +47,7 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy)
 
 
 
-#### register[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/registration.py#L283)
+#### register[↗](https://github.com/fetchai/uAgents/blob/main/python/src/uagents/registration.py#L287)
 ```python
 async def register(agent_identifier: str,
                    identity: Identity,

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 import requests
 from cosmpy.aerial.client import LedgerClient
-from pydantic.v1 import ValidationError
 from uagents_core.envelope import Envelope
 from uagents_core.identity import parse_identifier
 from uagents_core.models import ERROR_MESSAGE_DIGEST, ErrorMessage, Model
@@ -460,6 +459,7 @@ class InternalContext(Context):
         timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
         protocol_digest: str | None = None,
         queries: dict[str, asyncio.Future] | None = None,
+        expected_response_digests: set[str] | None = None,
     ) -> MsgStatus:
         # Extract address from destination agent identifier if present
         _, _, parsed_address = parse_identifier(destination)
@@ -471,6 +471,7 @@ class InternalContext(Context):
                     sender=self.agent.address,
                     destination=parsed_address,
                     session=self._session,
+                    expected_schema_digests=expected_response_digests,
                 )
             # Handle local dispatch of messages
             if dispatcher.contains(parsed_address):
@@ -613,6 +614,13 @@ class InternalContext(Context):
         """
         schema_digest = Model.build_schema_digest(message)
 
+        response_types: set[type[Model]] = (
+            {response_type} if isinstance(response_type, type) else response_type
+        )
+        response_type_by_digest: dict[str, type[Model]] = {
+            Model.build_schema_digest(r_type): r_type for r_type in response_types
+        }
+
         msg_status: MsgStatus = await self.send_raw(
             destination=destination,
             message_schema_digest=schema_digest,
@@ -620,6 +628,7 @@ class InternalContext(Context):
             sync=sync,
             wait_for_response=True,
             timeout=timeout,
+            expected_response_digests=set(response_type_by_digest),
         )
 
         _, _, parsed_address = parse_identifier(destination)
@@ -644,34 +653,8 @@ class InternalContext(Context):
                 session=self._session,
             )
 
-        response_types: set[type[Model]] = (
-            {response_type} if isinstance(response_type, type) else response_type
-        )
-
-        response: Model | None = None
-        for r_type in response_types:
-            if response_msg.schema_digest == Model.build_schema_digest(r_type):
-                try:
-                    response = r_type.parse_raw(response_msg.message)
-                    break
-                except ValidationError:
-                    pass
-
-        if response is None:
-            log(
-                logger=self.logger,
-                level=logging.ERROR,
-                message=f"Received unexpected response: {response_msg}",
-            )
-            msg_status = MsgStatus(
-                status=DeliveryStatus.FAILED,
-                detail="Received unexpected response type",
-                destination=destination,
-                endpoint="",
-                session=self._session,
-            )
-
-        return response, msg_status
+        r_type = response_type_by_digest[response_msg.schema_digest]
+        return r_type.parse_raw(response_msg.message), msg_status
 
     async def send_wallet_message(
         self,

--- a/python/src/uagents/dispatch.py
+++ b/python/src/uagents/dispatch.py
@@ -1,6 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
 from asyncio import Future
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
@@ -9,6 +10,20 @@ from uagents_core.models import Model
 from uagents.types import JsonStr, MsgInfo, RestMethod
 
 PendingResponseKey = tuple[str, str, UUID]
+
+
+@dataclass
+class PendingResponse:
+    future: Future[MsgInfo]
+    expected_schema_digests: set[str] | None = None
+
+    def accepts(self, schema_digest: str) -> bool:
+        """Whether an incoming message should resolve this response slot."""
+        if self.future.done():
+            return False
+        if self.expected_schema_digests is None:
+            return True
+        return schema_digest in self.expected_schema_digests
 
 
 class Sink(ABC):
@@ -36,21 +51,28 @@ class Dispatcher:
 
     def __init__(self):
         self._sinks: dict[str, set[Sink]] = {}
-        self._pending_responses: dict[PendingResponseKey, Future[MsgInfo]] = {}
+        self._pending_responses: dict[PendingResponseKey, PendingResponse] = {}
 
     @property
     def sinks(self) -> dict[str, set[Sink]]:
         return self._sinks
 
     @property
-    def pending_responses(self) -> dict[PendingResponseKey, Future[MsgInfo]]:
+    def pending_responses(self) -> dict[PendingResponseKey, PendingResponse]:
         return self._pending_responses
 
     async def register_pending_response(
-        self, sender: str, destination: str, session: UUID
+        self,
+        sender: str,
+        destination: str,
+        session: UUID,
+        expected_schema_digests: set[str] | None = None,
     ):
         loop = asyncio.get_running_loop()
-        self._pending_responses[(sender, destination, session)] = loop.create_future()
+        self._pending_responses[(sender, destination, session)] = PendingResponse(
+            future=loop.create_future(),
+            expected_schema_digests=expected_schema_digests,
+        )
 
     def cancel_pending_response(self, sender: str, destination: str, session: UUID):
         key: tuple[str, str, UUID] = (sender, destination, session)
@@ -62,7 +84,9 @@ class Dispatcher:
     ) -> MsgInfo | None:
         key: tuple[str, str, UUID] = (sender, destination, session)
         try:
-            response = await asyncio.wait_for(self._pending_responses[key], timeout)
+            response = await asyncio.wait_for(
+                self._pending_responses[key].future, timeout
+            )
         except asyncio.TimeoutError:
             response = None
         except KeyError:
@@ -82,9 +106,11 @@ class Dispatcher:
         message: JsonStr,
     ) -> bool:
         key = (destination, sender, session)
-        response = MsgInfo(message=message, sender=sender, schema_digest=schema_digest)
-        if key in self._pending_responses:
-            self._pending_responses[key].set_result(response)
+        pending = self._pending_responses.get(key)
+        if pending is not None and pending.accepts(schema_digest):
+            pending.future.set_result(
+                MsgInfo(message=message, sender=sender, schema_digest=schema_digest)
+            )
             return True
         return False
 

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -81,8 +81,9 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         async def _(ctx, sender, msg):
             pass
 
-        @proto1.on_message(model=Message, replies=Incoming)
+        @proto1.on_message(model=Message, replies={Incoming, Response})
         async def _(ctx, sender, msg):
+            await ctx.send(sender, Response(text="response"))
             await asyncio.sleep(1.1)
             await ctx.send(sender, incoming)
 
@@ -481,14 +482,15 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(dispatcher.pending_responses), 0)
 
     async def test_send_and_receive_async_success(self):
+        # Bob's handler sends a Response on the same session before the
+        # awaited Incoming arrives. The Response is routed to the regular handler
+        # while the Incoming is routed to the response future.
         context = self.alice._build_context()
 
-        # Perform the actual operation
         response, status = await context.send_and_receive(
             self.bob.address, msg, response_type=Incoming, timeout=5
         )
 
-        # Define the expected message status
         exp_msg_status = MsgStatus(
             status=DeliveryStatus.DELIVERED,
             detail="Message dispatched locally",
@@ -497,7 +499,6 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
             session=context.session,
         )
 
-        # Assertions
         self.assertEqual(status, exp_msg_status)
         self.assertEqual(response, incoming)
         self.assertEqual(len(dispatcher.pending_responses), 0)
@@ -529,21 +530,19 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         class WrongMessage(Model):
             wrong: str
 
-        # Perform the actual operation
         response, status = await context.send_and_receive(
-            self.bob.address, msg, response_type=WrongMessage, timeout=5
+            self.bob.address, msg, response_type=WrongMessage, timeout=2
         )
 
-        # Define the expected message status
         exp_msg_status = MsgStatus(
             status=DeliveryStatus.FAILED,
-            detail="Received unexpected response type",
+            detail="Timeout waiting for response",
             destination=self.bob.address,
             endpoint="",
             session=context.session,
         )
 
-        # Assertions
+        self.assertIsNone(response)
         self.assertEqual(status, exp_msg_status)
         self.assertEqual(len(dispatcher.pending_responses), 0)
 
@@ -581,21 +580,19 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         class WrongAgain(Model):
             wrong: str
 
-        # Perform the actual operation
         response, status = await context.send_and_receive(
-            self.bob.address, msg, response_type={WrongMessage, WrongAgain}, timeout=5
+            self.bob.address, msg, response_type={WrongMessage, WrongAgain}, timeout=2
         )
 
-        # Define the expected message status
         exp_msg_status = MsgStatus(
             status=DeliveryStatus.FAILED,
-            detail="Received unexpected response type",
+            detail="Timeout waiting for response",
             destination=self.bob.address,
             endpoint="",
             session=context.session,
         )
 
-        # Assertions
+        self.assertIsNone(response)
         self.assertEqual(status, exp_msg_status)
         self.assertEqual(len(dispatcher.pending_responses), 0)
 


### PR DESCRIPTION
## Proposed Changes

Unexpected responses to `ctx.send_and_receive` will now be discarded or routed to a dedicated handler rather than raise an exception in the current handler. 

## Linked Issues

#798 

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)