### PR TITLE
chore(uagents): suppress RPC error logging

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -60,6 +60,7 @@ from uagents.network import (
     InsufficientFundsError,
     get_almanac_contract,
     get_ledger,
+    is_ledger_rpc_unavailable,
 )
 from uagents.protocol import Protocol
 from uagents.registration import (
@@ -856,7 +857,13 @@ class Agent(Sink):
                 except InsufficientFundsError:
                     time_until_next_registration = 2 * AVERAGE_BLOCK_INTERVAL
                 except Exception as ex:
-                    self._logger.exception(f"Failed to register: {ex}")
+                    if is_ledger_rpc_unavailable(ex):
+                        self._logger.warning(
+                            "Ledger network unavailable; registration will retry later"
+                        )
+                        self._logger.debug(ex)
+                    else:
+                        self._logger.exception(f"Failed to register: {ex}")
                     time_until_next_registration = REGISTRATION_RETRY_INTERVAL_SECONDS
 
                 await asyncio.sleep(time_until_next_registration)
@@ -1686,7 +1693,13 @@ class Bureau:
                 except InsufficientFundsError:
                     time_to_next_registration = 2 * AVERAGE_BLOCK_INTERVAL
                 except Exception as ex:
-                    self._logger.exception(f"Failed to register: {ex}")
+                    if is_ledger_rpc_unavailable(ex):
+                        self._logger.warning(
+                            "Ledger network unavailable; registration will retry later"
+                        )
+                        self._logger.debug(ex)
+                    else:
+                        self._logger.exception(f"Failed to register: {ex}")
                     time_to_next_registration = REGISTRATION_RETRY_INTERVAL_SECONDS
 
                 await asyncio.sleep(time_to_next_registration)

--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -859,7 +859,7 @@ class Agent(Sink):
                 except Exception as ex:
                     if is_ledger_rpc_unavailable(ex):
                         self._logger.warning(
-                            "Ledger network unavailable; registration will retry later"
+                            "Ledger network unavailable. Registration will retry later"
                         )
                         self._logger.debug(ex)
                     else:
@@ -1695,7 +1695,7 @@ class Bureau:
                 except Exception as ex:
                     if is_ledger_rpc_unavailable(ex):
                         self._logger.warning(
-                            "Ledger network unavailable; registration will retry later"
+                            "Ledger network unavailable. Registration will retry later"
                         )
                         self._logger.debug(ex)
                     else:

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -6,7 +6,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from time import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import requests
 from cosmpy.aerial.client import LedgerClient

--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from logging import Logger
 from typing import Any
 
+import grpc
 from cosmpy.aerial.client import (
     DEFAULT_QUERY_INTERVAL_SECS,
     Account,
@@ -69,6 +70,24 @@ def block_polling_exp_backoff(retry: int) -> float:
 
 class InsufficientFundsError(Exception):
     """Raised when an agent has insufficient funds for a transaction."""
+
+
+_LEDGER_UNAVAILABLE_STATUS_CODES = frozenset[grpc.StatusCode](
+    {
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+    }
+)
+
+LEDGER_UNAVAILABLE_WARNING = (
+    "Ledger unavailable. Contract interactions temporarily disabled (will retry later)"
+)
+
+
+def is_ledger_rpc_unavailable(error: Exception) -> bool:
+    if isinstance(error, grpc.RpcError):
+        return error.code() in _LEDGER_UNAVAILABLE_STATUS_CODES
+    return False
 
 
 class BroadcastTimeoutError(RuntimeError):
@@ -223,10 +242,14 @@ class AlmanacContract(LedgerContract):
                 )
                 return False
         except Exception as e:
-            logger.error(
-                "Failed to query contract version. Contract interactions will be disabled."
-            )
-            logger.debug(e)
+            if is_ledger_rpc_unavailable(e):
+                logger.warning(LEDGER_UNAVAILABLE_WARNING)
+                logger.debug(e)
+            else:
+                logger.error(
+                    "Failed to query contract version. Contract interactions will be disabled."
+                )
+                logger.debug(e)
             return False
         return True
 
@@ -249,8 +272,12 @@ class AlmanacContract(LedgerContract):
                 raise ValueError("Invalid response format")
             return response
         except Exception as e:
-            logger.error(f"Query failed with error: {e.__class__.__name__}.")
-            logger.debug(e)
+            if not is_ledger_rpc_unavailable(e):
+                logger.error(f"Query failed with error: {e.__class__.__name__}.")
+                logger.debug(e)
+            else:
+                logger.debug(f"Ledger query failed: {e.__class__.__name__}")
+                logger.debug(e)
             raise
 
     def get_contract_version(self) -> str:
@@ -703,8 +730,14 @@ class NameServiceContract(LedgerContract):
                 raise ValueError("Invalid response format")
             return response
         except Exception as e:
-            logger.error(f"Querying NameServiceContract failed for query {query_msg}.")
-            logger.debug(e)
+            if is_ledger_rpc_unavailable(e):
+                logger.debug(f"NameService query failed: {e.__class__.__name__}")
+                logger.debug(e)
+            else:
+                logger.error(
+                    f"Querying NameServiceContract failed for query {query_msg}."
+                )
+                logger.debug(e)
             raise
 
     def get_oracle_agent_address(self):

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -304,7 +304,7 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
         except grpc.RpcError as e:
             if is_ledger_rpc_unavailable(e):
                 self._logger.warning(
-                    "Ledger unavailable; Almanac contract registration skipped "
+                    "Ledger unavailable. Almanac contract registration skipped "
                     "(will retry later)"
                 )
                 self._logger.debug(e)
@@ -499,7 +499,7 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
         except grpc.RpcError as e:
             if is_ledger_rpc_unavailable(e):
                 self._logger.warning(
-                    "Ledger network unavailable; Almanac contract registration skipped "
+                    "Ledger network unavailable. Almanac contract registration skipped "
                     "(will retry later)"
                 )
                 self._logger.debug(e)

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -38,6 +38,7 @@ from uagents.network import (
     RetryDelayFunc,
     add_testnet_funds,
     default_exp_backoff,
+    is_ledger_rpc_unavailable,
 )
 
 
@@ -296,6 +297,27 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
         Register the agent on the Almanac contract if registration is about to expire or
         the registration data has changed.
         """
+        try:
+            await self._register_on_almanac_contract(
+                agent_identifier, identity, protocols, endpoints
+            )
+        except grpc.RpcError as e:
+            if is_ledger_rpc_unavailable(e):
+                self._logger.warning(
+                    "Ledger unavailable; Almanac contract registration skipped "
+                    "(will retry later)"
+                )
+                self._logger.debug(e)
+            else:
+                raise
+
+    async def _register_on_almanac_contract(
+        self,
+        agent_identifier: str,
+        identity: Identity,
+        protocols: list[str],
+        endpoints: list[AgentEndpoint],
+    ) -> None:
         _, _, agent_address = parse_identifier(agent_identifier)
 
         if (
@@ -356,11 +378,6 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
                 self._last_successful_registration = datetime.now()
 
             except RuntimeError as e:
-                self._logger.warning(
-                    "Registering on almanac contract...failed (will retry later)"
-                )
-                self._logger.debug(e)
-            except grpc.RpcError as e:
                 self._logger.warning(
                     "Registering on almanac contract...failed (will retry later)"
                 )
@@ -477,6 +494,19 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
         return self._ledger.query_bank_balance(Address(self._wallet.address()))
 
     async def register(self) -> None:
+        try:
+            await self._register_agents_on_almanac_contract()
+        except grpc.RpcError as e:
+            if is_ledger_rpc_unavailable(e):
+                self._logger.warning(
+                    "Ledger network unavailable; Almanac contract registration skipped "
+                    "(will retry later)"
+                )
+                self._logger.debug(e)
+            else:
+                raise
+
+    async def _register_agents_on_almanac_contract(self) -> None:
         self._logger.info("Registering agents on Almanac contract...")
         for record in self._records:
             record.sign(self._identities[record.address])
@@ -512,11 +542,6 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
             self._last_successful_registration = datetime.now()
 
         except RuntimeError as e:
-            self._logger.warning(
-                "Registering on almanac contract...failed (will retry later)"
-            )
-            self._logger.debug(e)
-        except grpc.RpcError as e:
             self._logger.warning(
                 "Registering on almanac contract...failed (will retry later)"
             )


### PR DESCRIPTION
## Proposed Changes

Catch and show RPC unavailability errors as warnings rather than logging the entire stack traces.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)
