### PR TITLE
fix(core): langchain adapter content reply

### DIFF
--- a/python/uagents-core/uagents_core/agentverse/sdk/langchain/content.py
+++ b/python/uagents-core/uagents_core/agentverse/sdk/langchain/content.py
@@ -81,7 +81,7 @@ class SummariseData:
 
     def _trim(self, obj):
         if isinstance(obj, str):
-            return f"{obj[:self._max_len]}..." if len(obj) > self._max_len else obj
+            return f"{obj[: self._max_len]}..." if len(obj) > self._max_len else obj
         if isinstance(obj, dict):
             return {k: self._trim(v) for k, v in obj.items()}
         if isinstance(obj, list):
@@ -126,6 +126,7 @@ async def extract_ai_content(
             return content
 
     return []
+
 
 async def message_content_to_agent_content(
     content: str | list[dict[str, Any]], upload: Uploader | None = None

--- a/python/uagents-core/uagents_core/agentverse/sdk/langchain/content.py
+++ b/python/uagents-core/uagents_core/agentverse/sdk/langchain/content.py
@@ -89,13 +89,24 @@ class SummariseData:
         return obj
 
 
+def _turn_messages_since_last_human(messages: list[Any]) -> list[Any]:
+    last_human_idx = -1
+    for i, msg in enumerate(messages):
+        if isinstance(msg, dict) and msg.get("type") == "human":
+            last_human_idx = i
+    if last_human_idx < 0:
+        return messages
+    return messages[last_human_idx + 1 :]
+
+
 async def extract_ai_content(
     data: dict[str, Any], upload: Uploader | None = None
 ) -> list[AgentContent]:
-    """Extract AgentContent from all AI messages in a /runs/wait response.
+    """Extract AgentContent from the current turn in a /runs/wait response.
 
     Expects ``data["messages"]`` — the MessagesState convention for /runs/wait.
-    Processes every AI message in order.
+    Threaded runs return the full conversation history; only the latest reply
+    for the current user message is returned.
     """
     logger.debug("LangGraph response: %s", SummariseData(data))
 
@@ -103,19 +114,18 @@ async def extract_ai_content(
     if not isinstance(messages, list):
         messages = []
 
-    content: list[AgentContent] = []
-    for msg in messages:
+    turn_messages = _turn_messages_since_last_human(messages)
+
+    for msg in reversed(turn_messages):
         if not isinstance(msg, dict):
             continue
         if msg.get("type") not in ("ai", "tool"):
             continue
+        content = await message_content_to_agent_content(msg.get("content", ""), upload)
+        if content:
+            return content
 
-        content.extend(
-            await message_content_to_agent_content(msg.get("content", ""), upload)
-        )
-
-    return content
-
+    return []
 
 async def message_content_to_agent_content(
     content: str | list[dict[str, Any]], upload: Uploader | None = None

--- a/python/uagents-core/uv.lock
+++ b/python/uagents-core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1672,7 +1672,7 @@ wheels = [
 
 [[package]]
 name = "uagents-core"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "bech32" },


### PR DESCRIPTION
## Proposed Changes

This change avoids returning the full threaded message history, we now only inspect messages after the latest human turn and return the latest response

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
