### PR TITLE
chore(uagents): better dispense timeout and logging

### DIFF
--- a/python/src/uagents/communication.py
+++ b/python/src/uagents/communication.py
@@ -27,8 +27,12 @@ class Dispenser:
 
     def __init__(self):
         self._envelopes: asyncio.Queue[
-            tuple[Envelope, list[str], asyncio.Future, bool]
+            tuple[Envelope, list[str], asyncio.Future, bool, int]
         ] = asyncio.Queue()
+
+    def pending_count(self) -> int:
+        """Return the number of envelopes waiting in the dispenser queue."""
+        return self._envelopes.qsize()
 
     def add_envelope(
         self,
@@ -36,6 +40,7 @@ class Dispenser:
         endpoints: list[str],
         response_future: asyncio.Future,
         sync: bool = False,
+        timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
     ) -> None:
         """
         Add an envelope to the dispenser.
@@ -45,8 +50,11 @@ class Dispenser:
             endpoints (list[str]): The endpoints to send the envelope to.
             response_future (asyncio.Future): The future to set the response on.
             sync (bool): True if the message is synchronous. Defaults to False.
+            timeout (int): HTTP submit timeout in seconds. Defaults to 30.
         """
-        self._envelopes.put_nowait((envelope, endpoints, response_future, sync))
+        self._envelopes.put_nowait(
+            (envelope, endpoints, response_future, sync, timeout)
+        )
 
     async def _process_envelope(
         self,
@@ -54,6 +62,7 @@ class Dispenser:
         endpoints: list[str],
         response_future: asyncio.Future,
         sync: bool,
+        timeout: int,
     ) -> None:
         """
         Process a single envelope by sending it and updating the response future.
@@ -69,6 +78,7 @@ class Dispenser:
                 envelope=env,
                 endpoints=endpoints,
                 sync=sync,
+                timeout=timeout,
             )
             if not response_future.done():
                 response_future.set_result(result)
@@ -82,16 +92,32 @@ class Dispenser:
         """Run the dispenser routine."""
         try:
             while True:
-                env, endpoints, response_future, sync = await self._envelopes.get()
-                await self._process_envelope(env, endpoints, response_future, sync)
+                (
+                    env,
+                    endpoints,
+                    response_future,
+                    sync,
+                    timeout,
+                ) = await self._envelopes.get()
+                await self._process_envelope(
+                    env, endpoints, response_future, sync, timeout
+                )
         except (asyncio.CancelledError, KeyboardInterrupt):
             LOGGER.info("Shutting down dispenser...")
 
             # Drain remaining messages from queue using get_nowait()
             while not self._envelopes.empty():
                 try:
-                    env, endpoints, response_future, sync = self._envelopes.get_nowait()
-                    await self._process_envelope(env, endpoints, response_future, sync)
+                    (
+                        env,
+                        endpoints,
+                        response_future,
+                        sync,
+                        timeout,
+                    ) = self._envelopes.get_nowait()
+                    await self._process_envelope(
+                        env, endpoints, response_future, sync, timeout
+                    )
                 except asyncio.QueueEmpty:
                     break
                 except Exception as ex:
@@ -125,7 +151,10 @@ async def dispatch_local_message(
 
 
 async def send_exchange_envelope(
-    envelope: Envelope, endpoints: list[str], sync: bool = False
+    envelope: Envelope,
+    endpoints: list[str],
+    sync: bool = False,
+    timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
 ) -> MsgStatus | Envelope:
     """
     Method to send an exchange envelope.
@@ -134,6 +163,7 @@ async def send_exchange_envelope(
         envelope (Envelope): The envelope to send.
         endpoints (list[str]): The endpoints to send the envelope to.
         sync (bool): True if the message is synchronous. Defaults to False.
+        timeout (int): HTTP submit timeout in seconds. Defaults to 30.
 
     Returns:
         MsgStatus | Envelope: Either the status of the message or the response envelope.
@@ -141,10 +171,13 @@ async def send_exchange_envelope(
     headers = {"content-type": "application/json"}
     if sync:
         headers["x-uagents-connection"] = "sync"
-    errors = []
+    errors: list[str] = []
+    last_endpoint = ""
+    client_timeout = aiohttp.ClientTimeout(total=timeout)
     for endpoint in endpoints:
+        last_endpoint = endpoint
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=client_timeout) as session:
                 async with session.post(
                     endpoint,
                     headers=headers,
@@ -175,25 +208,29 @@ async def send_exchange_envelope(
                     body = await resp.text()
                     try:
                         error_json = json.loads(body)
-                        detail = error_json.get("detail", body)
+                        api_detail = error_json.get("detail", body)
                     except json.JSONDecodeError:
-                        detail = body
+                        api_detail = body
 
-                errors.append(f"{resp.status}: {detail}")
+                    errors.append(
+                        str(api_detail) if api_detail else f"HTTP {resp.status}"
+                    )
+        except (asyncio.TimeoutError, aiohttp.ServerTimeoutError):
+            errors.append(f"Message delivery timed out after {timeout}s")
         except aiohttp.ClientConnectorError as ex:
-            errors.append(f"Failed to connect: {ex}")
+            errors.append(f"Could not connect to {endpoint}: {ex}")
         except ValidationError as ex:
             errors.append(f"Invalid sync response: {ex}")
         except Exception as ex:
             errors.append(f"Failed to send message: {ex}")
     LOGGER.error(
-        f"Failed to deliver message to {envelope.target} @ {endpoints}: " + str(errors)
+        f"Failed to deliver message to {envelope.target} @ {endpoints}: {errors}"
     )
     return MsgStatus(
         status=DeliveryStatus.FAILED,
-        detail="Message delivery failed",
+        detail=errors[-1] if errors else "Message delivery failed",
         destination=envelope.target,
-        endpoint="",
+        endpoint=last_endpoint,
         session=envelope.session,
     )
 
@@ -289,6 +326,7 @@ async def send_message_raw(
         envelope=env,
         endpoints=endpoints,
         sync=sync,
+        timeout=timeout,
     )
     if isinstance(response, Envelope):
         if env.signature is None:

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -496,7 +496,7 @@ class InternalContext(Context):
                 )
                 result = MsgStatus(
                     status=DeliveryStatus.FAILED,
-                    detail="Unable to resolve destination endpoint",
+                    detail=f"No delivery endpoint found for agent {destination}",
                     destination=destination,
                     endpoint="",
                     session=self._session,
@@ -521,21 +521,23 @@ class InternalContext(Context):
                 # Create awaitable future for MsgStatus and sync response
                 fut = asyncio.Future()
 
-                self._queue_envelope(env, endpoints, fut, sync)
+                self._queue_envelope(env, endpoints, fut, sync, timeout)
 
                 try:
                     result = await asyncio.wait_for(fut, timeout)
                 except asyncio.TimeoutError:
-                    log(
-                        self.logger,
-                        logging.ERROR,
-                        "Timeout waiting for dispense response",
+                    primary_endpoint = endpoints[0] if endpoints else ""
+                    queued = self._dispenser.pending_count()
+                    detail = (
+                        f"Message delivery timed out after {timeout}s "
+                        f"(endpoint={primary_endpoint}, queued={queued})"
                     )
+                    log(self.logger, logging.ERROR, detail)
                     result = MsgStatus(
                         status=DeliveryStatus.FAILED,
-                        detail="Timeout waiting for response",
+                        detail=detail,
                         destination=destination,
-                        endpoint="",
+                        endpoint=primary_endpoint,
                         session=self._session,
                     )
 
@@ -560,6 +562,7 @@ class InternalContext(Context):
         endpoints: list[str],
         response_future: asyncio.Future,
         sync: bool = False,
+        timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
     ):
         """
         Queue an envelope for processing.
@@ -567,7 +570,9 @@ class InternalContext(Context):
         Args:
             envelope (Envelope): The envelope to queue.
         """
-        self._dispenser.add_envelope(envelope, endpoints, response_future, sync)
+        self._dispenser.add_envelope(
+            envelope, endpoints, response_future, sync, timeout
+        )
 
     async def send_and_receive(
         self,

--- a/python/tests/test_context.py
+++ b/python/tests/test_context.py
@@ -1,22 +1,45 @@
 # pylint: disable=protected-access
 import asyncio
 import unittest
+from typing import Any
 
 from aioresponses import aioresponses
 from uagents_core.envelope import Envelope
 
 from uagents import Agent, Protocol
 from uagents.agent import AgentRepresentation
-from uagents.context import (
-    DeliveryStatus,
-    ExternalContext,
-    Model,
-    MsgInfo,
-    MsgStatus,
-)
+from uagents.context import DeliveryStatus, ExternalContext, Model, MsgInfo, MsgStatus
 from uagents.crypto import Identity
 from uagents.dispatch import dispatcher
 from uagents.resolver import RulesBasedResolver
+
+# ``POST /v2/agents/mailbox/submit`` error strings
+TARGET_AGENT_NOT_FOUND = "Target agent not found"
+INVALID_ENVELOPE_SIGNATURE = "Invalid envelope signature"
+AGENT_OWNER_NOT_FOUND = "Agent owner not found"
+MESSAGE_QUOTA_REACHED = "Message quota reached for this agent"
+
+
+def mock_mailbox_submit(
+    mocked_responses: Any,
+    url: str,
+    *,
+    status: int = 200,
+    detail: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Register an aioresponses POST mock with FastAPI ``{"detail": ...}`` errors."""
+    if status == 200:
+        mocked_responses.post(
+            url, status=200, payload={} if payload is None else payload
+        )
+        return
+
+    mocked_responses.post(
+        url,
+        status=status,
+        payload={"detail": detail or ""},
+    )
 
 
 class Incoming(Model):
@@ -265,7 +288,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         result = await context.send(destination, msg)
         exp_msg_status = MsgStatus(
             status=DeliveryStatus.FAILED,
-            detail="Unable to resolve destination endpoint",
+            detail=f"No delivery endpoint found for agent {destination}",
             destination=destination,
             endpoint="",
             session=context.session,
@@ -275,8 +298,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
 
     @aioresponses()
     async def test_send_external_dispatch_success(self, mocked_responses):
-        # Mock the HTTP POST request with a status code and response content
-        mocked_responses.post(endpoints[0], status=200)
+        mock_mailbox_submit(mocked_responses, endpoints[0], status=200)
 
         context = self.alice._build_context()
 
@@ -297,24 +319,47 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
 
     @aioresponses()
     async def test_send_external_dispatch_failure(self, mocked_responses):
-        # Mock the HTTP POST request with a status code and response content
-        mocked_responses.post(endpoints[0], status=404)
+        mock_mailbox_submit(
+            mocked_responses,
+            endpoints[0],
+            status=404,
+            detail=TARGET_AGENT_NOT_FOUND,
+        )
 
         context = self.alice._build_context()
 
-        # Perform the actual operation
         result = await context.send(self.clyde.address, msg)
 
-        # Define the expected message status
         exp_msg_status = MsgStatus(
             status=DeliveryStatus.FAILED,
-            detail="Message delivery failed",
+            detail=TARGET_AGENT_NOT_FOUND,
             destination=self.clyde.address,
-            endpoint="",
+            endpoint=endpoints[0],
             session=context.session,
         )
 
-        # Assertions
+        self.assertEqual(result, exp_msg_status)
+
+    @aioresponses()
+    async def test_send_external_dispatch_invalid_signature(self, mocked_responses):
+        mock_mailbox_submit(
+            mocked_responses,
+            endpoints[0],
+            status=400,
+            detail=INVALID_ENVELOPE_SIGNATURE,
+        )
+
+        context = self.alice._build_context()
+        result = await context.send(self.clyde.address, msg)
+
+        exp_msg_status = MsgStatus(
+            status=DeliveryStatus.FAILED,
+            detail=INVALID_ENVELOPE_SIGNATURE,
+            destination=self.clyde.address,
+            endpoint=endpoints[0],
+            session=context.session,
+        )
+
         self.assertEqual(result, exp_msg_status)
 
     @aioresponses()
@@ -323,9 +368,13 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
     ):
         endpoints.append("http://localhost:8001")
 
-        # Mock the HTTP POST request with a status code and response content
-        mocked_responses.post(endpoints[0], status=200)
-        mocked_responses.post(endpoints[1], status=404)
+        mock_mailbox_submit(mocked_responses, endpoints[0], status=200)
+        mock_mailbox_submit(
+            mocked_responses,
+            endpoints[1],
+            status=404,
+            detail=TARGET_AGENT_NOT_FOUND,
+        )
 
         context = self.alice._build_context()
 
@@ -355,9 +404,13 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
     ):
         endpoints.append("http://localhost:8001")
 
-        # Mock the HTTP POST request with a status code and response content
-        mocked_responses.post(endpoints[0], status=404)
-        mocked_responses.post(endpoints[1], status=200)
+        mock_mailbox_submit(
+            mocked_responses,
+            endpoints[0],
+            status=404,
+            detail=TARGET_AGENT_NOT_FOUND,
+        )
+        mock_mailbox_submit(mocked_responses, endpoints[1], status=200)
 
         context = self.alice._build_context()
 
@@ -384,21 +437,28 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
     ):
         endpoints.append("http://localhost:8001")
 
-        # Mock the HTTP POST request with a status code and response content
-        mocked_responses.post(endpoints[0], status=404)
-        mocked_responses.post(endpoints[1], status=404)
+        mock_mailbox_submit(
+            mocked_responses,
+            endpoints[0],
+            status=404,
+            detail=TARGET_AGENT_NOT_FOUND,
+        )
+        mock_mailbox_submit(
+            mocked_responses,
+            endpoints[1],
+            status=404,
+            detail=TARGET_AGENT_NOT_FOUND,
+        )
 
         context = self.alice._build_context()
 
-        # Perform the actual operation
         result = await context.send(self.clyde.address, msg)
 
-        # Define the expected message status
         exp_msg_status = MsgStatus(
             status=DeliveryStatus.FAILED,
-            detail="Message delivery failed",
+            detail=TARGET_AGENT_NOT_FOUND,
             destination=self.clyde.address,
-            endpoint="",
+            endpoint=endpoints[1],
             session=context.session,
         )
 
@@ -423,7 +483,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         env.sign(self.clyde._identity)
         payload = env.model_dump()
         payload["session"] = str(env.session)
-        mocked_responses.post(endpoints[0], status=200, payload=payload)
+        mock_mailbox_submit(mocked_responses, endpoints[0], status=200, payload=payload)
 
         # Perform the actual operation
         response, status = await context.send_and_receive(
@@ -460,7 +520,7 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         env.sign(self.clyde._identity)
         payload = env.model_dump()
         payload["session"] = str(env.session)
-        mocked_responses.post(endpoints[0], status=200, payload=payload)
+        mock_mailbox_submit(mocked_responses, endpoints[0], status=200, payload=payload)
 
         # Perform the actual operation
         _, status = await context.send_and_receive(
@@ -470,9 +530,9 @@ class TestContextSendMethods(unittest.IsolatedAsyncioTestCase):
         # Define the expected message status
         exp_msg_status = MsgStatus(
             status=DeliveryStatus.FAILED,
-            detail="Timeout waiting for response",
+            detail=f"Message delivery timed out after 0s (endpoint={endpoints[0]}, queued=0)",
             destination=self.clyde.address,
-            endpoint="",
+            endpoint=endpoints[0],
             session=context.session,
         )
 


### PR DESCRIPTION
## Proposed Changes

Improve outbound message error reporting so failures surface useful detail in `MsgStatus.detail` and logs.

- Pass through HTTP API error bodies directly (FastAPI `detail` field) instead of a generic "Message delivery failed".
- Propagate per-send timeout through the dispenser queue and apply it to `aiohttp` POSTs (`ClientTimeout`).
- On dispenser wait timeout, include endpoint and queue depth in the error: `Message delivery timed out after Ns (endpoint=..., queued=...)`.
- Clearer errors for unresolved destinations and connection failures.
- Set `MsgStatus.endpoint` to the endpoint that was actually tried on failure.
- Tests updated to mock real responses and assert passthrough strings.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)