### PR TITLE
fix(uagents): prevent sync-query future leak and cross-talk in ASGI server

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -248,8 +248,8 @@ class Agent(Sink):
         _models (dict[str, type[Model]]): Dictionary mapping supported message digests to messages.
         _replies (dict[str, dict[str, type[Model]]]): Dictionary of allowed replies for each type
         of incoming message.
-        _queries (dict[str, asyncio.Future]): Dictionary mapping query senders to their response
-        Futures.
+        _queries (dict[tuple[str, uuid.UUID], asyncio.Future]): Maps
+            (query sender, session) to their response Futures.
         _dispatcher: The dispatcher for internal handling/sorting of messages.
         _dispenser: The dispatcher for external message handling.
         _message_queue: Asynchronous queue for incoming messages.
@@ -394,7 +394,7 @@ class Agent(Sink):
         self._rest_handlers: RestHandlerMap = {}
         self._models: dict[str, type[Model]] = {}
         self._replies: dict[str, dict[str, type[Model]]] = {}
-        self._queries: dict[str, asyncio.Future] = {}
+        self._queries: dict[tuple[str, uuid.UUID], asyncio.Future] = {}
         self._dispatcher = dispatcher
         self._message_history: EnvelopeHistory | None = (
             EnvelopeHistory(
@@ -1530,8 +1530,8 @@ class Bureau:
         _agents (list[Agent]): The list of agents to be managed by the bureau.
         _endpoints (list[dict[str, Any]]): The endpoint configuration for the bureau.
         _port (int): The port on which the bureau's server runs.
-        _queries (dict[str, asyncio.Future]): dictionary mapping query senders to their
-        response Futures.
+        _queries (dict[tuple[str, uuid.UUID], asyncio.Future]): Maps
+            (query sender, session) to their response Futures.
         _logger (Logger): The logger instance.
         _server (ASGIServer): The ASGI server instance for handling requests.
         _agentverse (AgentverseConfig): The agentverse configuration for the bureau.
@@ -1575,7 +1575,7 @@ class Bureau:
         self._loop = loop or asyncio.get_event_loop_policy().get_event_loop()
         self._agents: list[Agent] = []
         self._port = port or 8000
-        self._queries: dict[str, asyncio.Future] = {}
+        self._queries: dict[tuple[str, uuid.UUID], asyncio.Future] = {}
         self._logger = get_logger("bureau", log_level)
         self._server = ASGIServer(
             port=self._port,

--- a/python/src/uagents/asgi.py
+++ b/python/src/uagents/asgi.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+import uuid
 from datetime import datetime, timezone
 from logging import Logger
 from typing import Any
@@ -45,7 +46,7 @@ class ASGIServer:
         self,
         port: int,
         loop: asyncio.AbstractEventLoop,
-        queries: dict[str, asyncio.Future],
+        queries: dict[tuple[str, uuid.UUID], asyncio.Future],
         logger: Logger | None = None,
     ):
         """
@@ -54,7 +55,8 @@ class ASGIServer:
         Args:
             port (int): The port to listen on.
             loop (asyncio.AbstractEventLoop): The event loop to use.
-            queries (dict[str, asyncio.Future]): The dictionary of queries to resolve.
+            queries (dict[tuple[str, uuid.UUID], asyncio.Future]):
+                The pending sync-query futures, keyed by (sender, session).
             logger (Logger | None): The logger to use.
         """
         self._port = int(port)
@@ -356,10 +358,6 @@ class ASGIServer:
 
         expects_response = headers.get(b"x-uagents-connection") == b"sync"  # type: ignore
 
-        if expects_response:
-            # Add a future that will be resolved once the query is answered
-            self._queries[env.sender] = asyncio.Future()
-
         if not is_user_address(env.sender):  # verify signature if sent from agent
             try:
                 env.verify()
@@ -375,6 +373,14 @@ class ASGIServer:
                 send=send, status_code=400, body={"error": "unable to route envelope"}
             )
             return
+
+        query_key = (env.sender, env.session)
+        if expects_response:
+            # Add a future that will be resolved once the query is answered.
+            # Registered only after signature + routing checks pass, and keyed
+            # by (sender, session) so concurrent queries never collide and no
+            # entry is leaked on the verify-fail / unroutable / timeout paths.
+            self._queries[query_key] = asyncio.Future()
 
         await dispatcher.dispatch_msg(
             sender=env.sender,
@@ -393,7 +399,7 @@ class ASGIServer:
             )
             try:
                 response_msg, schema_digest = await asyncio.wait_for(
-                    self._queries[env.sender],
+                    self._queries[query_key],
                     timeout,
                 )
             except asyncio.TimeoutError:
@@ -401,6 +407,11 @@ class ASGIServer:
                     error="Query envelope expired"
                 ).model_dump_json()
                 schema_digest = ERROR_MESSAGE_DIGEST
+            finally:
+                # Guarantee cleanup on every exit (resolved, timed out, or
+                # cancelled). Happy path already removed it in context.send_raw,
+                # so pop() with a default is a safe no-op there.
+                self._queries.pop(query_key, None)
             sender = env.target
             target = env.sender
             response = enclose_response_raw(

--- a/python/src/uagents/context.py
+++ b/python/src/uagents/context.py
@@ -197,7 +197,7 @@ class Context(ABC):
         wait_for_response: bool = False,
         timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
         protocol_digest: str | None = None,
-        queries: dict[str, asyncio.Future] | None = None,
+        queries: dict[tuple[str, uuid.UUID], asyncio.Future] | None = None,
     ) -> MsgStatus:
         """
         Send a message to the specified destination where the message body and
@@ -211,7 +211,8 @@ class Context(ABC):
             wait_for_response (bool): Whether to wait for a response to the message.
             timeout (int, optional): The optional timeout for sending the message, in seconds.
             protocol_digest (str, optional): The protocol digest of the message to be sent.
-            queries (dict[str, asyncio.Future] | None): The dictionary of queries to resolve.
+            queries (dict[tuple[str, uuid.UUID], asyncio.Future] | None):
+                The pending sync-query futures, keyed by (sender, session).
 
         Returns:
             MsgStatus: The delivery status of the message.
@@ -436,7 +437,7 @@ class InternalContext(Context):
         wait_for_response: bool = False,
         timeout: int = DEFAULT_ENVELOPE_TIMEOUT_SECONDS,
         protocol_digest: str | None = None,
-        queries: dict[str, asyncio.Future] | None = None,
+        queries: dict[tuple[str, uuid.UUID], asyncio.Future] | None = None,
         expected_response_digests: set[str] | None = None,
     ) -> MsgStatus:
         # Extract address from destination agent identifier if present
@@ -462,11 +463,13 @@ class InternalContext(Context):
                 )
 
             # Handle sync dispatch of messages
-            elif queries and parsed_address in queries:
-                queries[parsed_address].set_result(
+            # Queries are keyed by (original_sender, session) so a reply only
+            # resolves the specific query it belongs to.
+            elif queries and (parsed_address, self._session) in queries:
+                queries[(parsed_address, self._session)].set_result(
                     (message_body, message_schema_digest)
                 )
-                del queries[parsed_address]
+                del queries[(parsed_address, self._session)]
                 result = MsgStatus(
                     status=DeliveryStatus.DELIVERED,
                     detail="Sync message resolved",
@@ -641,8 +644,8 @@ class ExternalContext(InternalContext):
 
     Attributes:
         _message_received (MsgInfo): The received message.
-        _queries (dict[str, asyncio.Future] | None): dictionary mapping query senders to their
-            response Futures.
+        _queries (dict[tuple[str, uuid.UUID], asyncio.Future] | None): Maps
+            (query sender, session) to their response Futures.
         _replies (dict[str, dict[str, type[Model]]] | None): Dictionary of allowed reply digests
             for each type of incoming message.
         _protocol (tuple[str, Protocol] | None): The supported protocol digest
@@ -652,7 +655,7 @@ class ExternalContext(InternalContext):
     def __init__(
         self,
         message_received: MsgInfo,
-        queries: dict[str, asyncio.Future] | None = None,
+        queries: dict[tuple[str, uuid.UUID], asyncio.Future] | None = None,
         replies: dict[str, dict[str, type[Model]]] | None = None,
         protocol: tuple[str, "Protocol"] | None = None,
         **kwargs,
@@ -662,8 +665,8 @@ class ExternalContext(InternalContext):
 
         Args:
             message_received (MsgInfo): Information about the received message.
-            queries (dict[str, asyncio.Future]): Dictionary mapping query senders to their
-                response Futures.
+            queries (dict[tuple[str, uuid.UUID], asyncio.Future]): Maps
+                (query sender, session) to their response Futures.
             replies (dict[str, dict[str, type[Model]]] | None): Dictionary of allowed replies
                 for each type of incoming message.
             protocol (tuple[str, Protocol] | None): The optional tuple of protocols.

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -26,8 +26,11 @@ class TestServer(unittest.IsolatedAsyncioTestCase):
 
     async def mock_process_sync_message(self, sender: str, msg: Model):
         while True:
-            if sender in self.agent._server._queries:
-                self.agent._server._queries[sender].set_result(
+            key = next(
+                (k for k in self.agent._server._queries if k[0] == sender), None
+            )
+            if key is not None:
+                self.agent._server._queries[key].set_result(
                     (msg.model_dump_json(), Model.build_schema_digest(msg))
                 )
                 return


### PR DESCRIPTION
## Summary

The ASGI `/submit` handler leaked entries in the server-side sync-response map
(`ASGIServer._queries`) and could cross-wire concurrent sync queries.

`_queries[env.sender]` was created **before** the envelope signature was verified
and **before** the target was confirmed routable, and it was never removed on the
failure paths:

- signature verification failed → early `return` (entry leaked)
- target not routable → early `return` (entry leaked)
- sync request timed out waiting for a reply → no cleanup (entry leaked)

Only the happy path (handler replies) removed the entry, via `context.send_raw`.

### Impact

- **Unauthenticated memory-exhaustion DoS.** `/submit` needs no auth. A caller
  sending sync requests (`x-uagents-connection: sync`) with a `user...` sender
  (signature check skipped) and any unroutable target adds a permanent dict entry
  per request. The key is `env.sender`, an arbitrary wire string, so each entry's
  size is attacker-controlled. The dict never shrinks.
- **Concurrent-query cross-talk.** `_queries` was keyed by `sender` only, so two
  in-flight sync queries from the same caller collided (second overwrote the
  first's Future).

## Fix

- Register the response Future **only after** signature + routing checks pass.
- Key `_queries` by `(sender, session)` so concurrent queries never collide.
- Remove the entry in a `finally` around the sync wait (happy path already
  deletes it in `context.send_raw`, so `pop(..., None)` is a safe no-op there).
- Resolve replies by `(sender, session)` in `context.send_raw`; update type hints.

Files: `asgi.py`, `context.py`, `agent.py` (type hints), `tests/test_server.py`
(sync helper updated for the tuple key).

## Testing

- Existing suites pass: `test_server`, `test_context`, `test_agent`,
  `test_protocol`, `test_msg_verify`.
- Verified end-to-end (asgi → message queue → consumer → `on_message` handler →
  `ctx.send` → future resolved), plus failure/timeout/concurrency/load cases:
  every failure, timeout, and unroutable path leaves `_queries` empty; concurrent
  same-sender / different-session queries each receive their own reply with no
  cross-talk.
- `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
