### PR TITLE
docs: fix AgentRepresentation docstring attributes

### DIFF
--- a/python/src/uagents/agent.py
+++ b/python/src/uagents/agent.py
@@ -145,13 +145,8 @@ class AgentRepresentation:
     Represents an agent in the context of a message.
 
     Attributes:
-        _address (str): The address of the agent.
-        _name (str | None): The name of the agent.
-        _identity (Identity): The identity of the agent.
-
-    Properties:
-        name (str): The name of the agent.
         address (str): The address of the agent.
+        name (str): The name of the agent.
         identifier (str): The agent's address and network prefix.
         identity (Identity): The identity of the agent.
     """


### PR DESCRIPTION
Fixed outdated docstring in AgentRepresentation class.

- Removed stale "Properties" section header
- Aligned documented attributes with actual implementation
- Fixes #919

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>