### PR TITLE
feat(experimental): stream ChatAgent replies

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -62,7 +62,8 @@ jobs:
 
       - if: ${{ needs.check-if-files-changed.outputs.uagents == 'true' }}
         name: Install dependencies
-        run: uv sync --locked
+        # llm extra needed for experimental ChatAgent tests (litellm)
+        run: uv sync --locked --extra llm
       - if: ${{ needs.check-if-files-changed.outputs.uagents == 'true' }}
         name: Run tests
         run: uv run coverage run -m pytest

--- a/python/src/uagents/experimental/chat_agent/README.md
+++ b/python/src/uagents/experimental/chat_agent/README.md
@@ -74,6 +74,7 @@ openai_config = LLMConfig(
     model="gpt-5-mini",
     url="https://api.openai.com/v1",
     parameters=LLMParams(temperature=1),
+    # stream=True by default. Set stream=False for providers that do not support streaming.
 )
 
 claude_config = LLMConfig(
@@ -82,6 +83,7 @@ claude_config = LLMConfig(
     model="claude-4-5-haiku",
     url="https://api.anthropic.com/v1/messages",
     parameters=LLMParams(),
+    stream=False,  # non-streaming full replies
 )
 
 agent = ChatAgent(name="MathChat", llm_config=asione_config)

--- a/python/src/uagents/experimental/chat_agent/llm.py
+++ b/python/src/uagents/experimental/chat_agent/llm.py
@@ -87,7 +87,7 @@ class LLMConfig(BaseModel):
     url: str
     parameters: LLMParams
     api_key: str | None = None
-    stream: bool = True # Set False for providers that do not support stream
+    stream: bool = True  # Set False for providers that do not support stream
 
     @classmethod
     def asi1(cls, model: str = DEFAULT_ASI1_MODEL, stream: bool = True) -> "LLMConfig":

--- a/python/src/uagents/experimental/chat_agent/llm.py
+++ b/python/src/uagents/experimental/chat_agent/llm.py
@@ -87,9 +87,10 @@ class LLMConfig(BaseModel):
     url: str
     parameters: LLMParams
     api_key: str | None = None
+    stream: bool = True # Set False for providers that do not support stream
 
     @classmethod
-    def asi1(cls, model: str = DEFAULT_ASI1_MODEL) -> "LLMConfig":
+    def asi1(cls, model: str = DEFAULT_ASI1_MODEL, stream: bool = True) -> "LLMConfig":
         api_key = os.getenv("ASI1_API_KEY")
         if api_key is None:
             raise ValueError("Please set ASI1_API_KEY environment variable.")
@@ -99,6 +100,7 @@ class LLMConfig(BaseModel):
             model=model,
             url=os.getenv("ASI1_BASE_URL", DEFAULT_ASI1_URL),
             parameters=LLMParams(),
+            stream=stream,
         )
 
 
@@ -218,7 +220,10 @@ class LLM:
         try:
             response = await acompletion(**kwargs)
         except Exception as e:
-            raise RuntimeError(_provider_error_message(e)) from e
+            raise RuntimeError(
+                "Streaming is enabled for this ChatAgent, but the LLM provider "
+                f"failed to stream a reply: {_provider_error_message(e)}"
+            ) from e
 
         async for chunk in response:
             choices = getattr(chunk, "choices", None) or []

--- a/python/src/uagents/experimental/chat_agent/llm.py
+++ b/python/src/uagents/experimental/chat_agent/llm.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import logging
 import os
+from collections.abc import AsyncIterator
 from typing import Any, cast
 
 import litellm
@@ -208,6 +209,30 @@ class LLM:
             return ("__plain_text__", {"message": content_text}, None, msg)
 
         raise RuntimeError("LLM returned neither tool_calls nor content.")
+
+    async def process_stream(
+        self, messages: list[dict]
+    ) -> AsyncIterator[str]:
+        """Yield plain-text content deltas from a streaming completion."""
+        kwargs = self._get_base_kwargs(
+            messages, exclude_params={"system_prompt", "tool_choice"}
+        )
+        kwargs["stream"] = True
+        kwargs.pop("parallel_tool_calls", None)
+
+        try:
+            response = await acompletion(**kwargs)
+        except Exception as e:
+            raise RuntimeError(_provider_error_message(e)) from e
+
+        async for chunk in response:
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            delta = getattr(choices[0], "delta", None)
+            text = getattr(delta, "content", None) if delta is not None else None
+            if text:
+                yield text
 
     async def complete(self, messages: list[dict]) -> str:
         """Finalize a chat turn after tool execution."""

--- a/python/src/uagents/experimental/chat_agent/llm.py
+++ b/python/src/uagents/experimental/chat_agent/llm.py
@@ -16,9 +16,6 @@ from pydantic import BaseModel, ConfigDict
 from uagents.experimental.chat_agent.tools import Tool
 
 
-# LiteLLM keeps shared HTTP clients; they must be closed when the process exits. The
-# library registers its own atexit hook, but we also run this so cleanup is awaited
-# reliably (e.g. after Bureau/agent teardown when no asyncio loop is running).
 def _litellm_cleanup_on_exit() -> None:
     with contextlib.suppress(Exception):
         asyncio.run(close_litellm_async_clients())
@@ -210,9 +207,7 @@ class LLM:
 
         raise RuntimeError("LLM returned neither tool_calls nor content.")
 
-    async def process_stream(
-        self, messages: list[dict]
-    ) -> AsyncIterator[str]:
+    async def process_stream(self, messages: list[dict]) -> AsyncIterator[str]:
         """Yield plain-text content deltas from a streaming completion."""
         kwargs = self._get_base_kwargs(
             messages, exclude_params={"system_prompt", "tool_choice"}

--- a/python/src/uagents/experimental/chat_agent/protocol.py
+++ b/python/src/uagents/experimental/chat_agent/protocol.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 from typing import cast
+from uuid import uuid4
 
 from pydantic.v1 import ValidationError
 from uagents_core.contrib.protocols.chat import (
@@ -8,7 +9,9 @@ from uagents_core.contrib.protocols.chat import (
     ChatAcknowledgement,
     ChatMessage,
     EndSessionContent,
+    EndStreamContent,
     StartSessionContent,
+    StartStreamContent,
     TextContent,
     chat_protocol_spec,
 )
@@ -143,8 +146,31 @@ class ChatProtocol(Protocol):
                 ):
                     messages = [*messages, msg_dict]
 
+            # No tools: stream the plain-text reply directly.
+            if not self._tools:
+                try:
+                    return await self.send_stream(
+                        ctx,
+                        sender,
+                        [
+                            {
+                                "role": "system",
+                                "content": self._llm._system_content([]),
+                            },
+                            *messages,
+                        ],
+                    )
+                except Exception as e:
+                    ctx.logger.error(f"LLM failed: {e}")
+                    return await self.send_text(
+                        ctx, sender, f"Sorry, I couldn't process that: {e}"
+                    )
+
+            # Tool selection stays non-streaming so the full call is available.
             try:
-                tool_name, arg_dict, tool_call_id, _ = await self._llm.process(messages)
+                tool_name, arg_dict, tool_call_id, assistant_msg = (
+                    await self._llm.process(messages)
+                )
 
             except Exception as e:
                 ctx.logger.error(f"LLM failed: {e}")
@@ -186,27 +212,29 @@ class ChatProtocol(Protocol):
                     "Sorry, I couldn't process your request. Please try again later.",
                 )
 
-            tool_result_message = {
-                "role": "tool",
-                "tool_call_id": tool_call_id,
-                "content": json.dumps(result),
-            }
-
+            # Providers require the assistant tool_calls message before role=tool.
             followup_messages = [
                 {"role": "system", "content": FINAL_SYSTEM_PROMPT},
                 msg_dict,
-                tool_result_message,
+                {
+                    "role": "assistant",
+                    "content": assistant_msg.get("content"),
+                    "tool_calls": assistant_msg.get("tool_calls"),
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": json.dumps(result),
+                },
             ]
 
             try:
-                final_text = await self._llm.complete(followup_messages)
+                return await self.send_stream(ctx, sender, followup_messages)
             except Exception as e:
                 ctx.logger.error(f"LLM failed after tool use: {e}")
                 return await self.send_text(
                     ctx, sender, f"Sorry, I couldn't process that: {e}"
                 )
-
-            return await self.send_text(ctx, sender, final_text)
 
     async def send_text(
         self,
@@ -220,6 +248,41 @@ class ChatProtocol(Protocol):
         if end_session:
             content.append(EndSessionContent(type="end-session"))
         return await ctx.send(recipient, ChatMessage(content=content))
+
+    async def send_stream(
+        self,
+        ctx: Context,
+        recipient: str,
+        messages: list[dict],
+    ):
+        """Stream an LLM reply as StartStream → TextContent deltas → EndStream."""
+        stream_id = uuid4()
+        started = False
+        try:
+            async for delta in self._llm.process_stream(messages):
+                if not started:
+                    await ctx.send(
+                        recipient,
+                        ChatMessage(content=[StartStreamContent(stream_id=stream_id)]),
+                    )
+                    started = True
+                await ctx.send(
+                    recipient,
+                    ChatMessage(content=[TextContent(type="text", text=delta)]),
+                )
+            if not started:
+                raise RuntimeError("LLM stream returned no content.")
+            return await ctx.send(
+                recipient,
+                ChatMessage(content=[EndStreamContent(stream_id=stream_id)]),
+            )
+        except Exception:
+            if started:
+                await ctx.send(
+                    recipient,
+                    ChatMessage(content=[EndStreamContent(stream_id=stream_id)]),
+                )
+            raise
 
     async def use_tool(
         self,

--- a/python/src/uagents/experimental/chat_agent/protocol.py
+++ b/python/src/uagents/experimental/chat_agent/protocol.py
@@ -108,6 +108,7 @@ class ChatProtocol(Protocol):
 
         self._llm = LLM(config=llm_config, tools=tools, instructions=instructions)
         self._tools = tools
+        self._stream = llm_config.stream
 
         @self.on_message(ChatAcknowledgement)
         async def _ack(ctx: Context, sender: str, msg: ChatAcknowledgement):
@@ -148,7 +149,7 @@ class ChatProtocol(Protocol):
 
             if not self._tools:
                 try:
-                    return await self.send_stream(
+                    return await self.send_reply(
                         ctx,
                         sender,
                         [
@@ -230,7 +231,7 @@ class ChatProtocol(Protocol):
             ]
 
             try:
-                return await self.send_stream(ctx, sender, followup_messages)
+                return await self.send_reply(ctx, sender, followup_messages)
             except Exception as e:
                 ctx.logger.error(f"LLM failed after tool use: {e}")
                 return await self.send_text(
@@ -249,6 +250,19 @@ class ChatProtocol(Protocol):
         if end_session:
             content.append(EndSessionContent(type="end-session"))
         return await ctx.send(recipient, ChatMessage(content=content))
+
+    async def send_reply(
+        self,
+        ctx: Context,
+        recipient: str,
+        messages: list[dict],
+    ):
+        """Send a user-facing LLM reply, streaming when LLMConfig.stream is True."""
+        if self._stream:
+            return await self.send_stream(ctx, recipient, messages)
+
+        text = await self._llm.complete(messages)
+        return await self.send_text(ctx, recipient, text)
 
     async def send_stream(
         self,
@@ -272,7 +286,10 @@ class ChatProtocol(Protocol):
                     ChatMessage(content=[TextContent(type="text", text=delta)]),
                 )
             if not started:
-                raise RuntimeError("LLM stream returned no content.")
+                raise RuntimeError(
+                    "Streaming is enabled for this ChatAgent, but the LLM provider "
+                    "returned no streamed content."
+                )
             return await ctx.send(
                 recipient,
                 ChatMessage(content=[EndStreamContent(stream_id=stream_id)]),

--- a/python/src/uagents/experimental/chat_agent/protocol.py
+++ b/python/src/uagents/experimental/chat_agent/protocol.py
@@ -146,7 +146,6 @@ class ChatProtocol(Protocol):
                 ):
                     messages = [*messages, msg_dict]
 
-            # No tools: stream the plain-text reply directly.
             if not self._tools:
                 try:
                     return await self.send_stream(
@@ -166,11 +165,13 @@ class ChatProtocol(Protocol):
                         ctx, sender, f"Sorry, I couldn't process that: {e}"
                     )
 
-            # Tool selection stays non-streaming so the full call is available.
             try:
-                tool_name, arg_dict, tool_call_id, assistant_msg = (
-                    await self._llm.process(messages)
-                )
+                (
+                    tool_name,
+                    arg_dict,
+                    tool_call_id,
+                    assistant_msg,
+                ) = await self._llm.process(messages)
 
             except Exception as e:
                 ctx.logger.error(f"LLM failed: {e}")

--- a/python/tests/test_chat_agent_streaming.py
+++ b/python/tests/test_chat_agent_streaming.py
@@ -105,3 +105,39 @@ async def test_send_stream_emits_start_text_end():
     )
     assert isinstance(sent[3].content[0], EndStreamContent)
     assert sent[0].content[0].stream_id == sent[3].content[0].stream_id
+
+
+@pytest.mark.asyncio
+async def test_send_reply_non_streaming_sends_single_text():
+    proto = ChatProtocol(
+        llm_config=LLMConfig(
+            provider="openai",
+            model="test-model",
+            url="https://example.test/v1",
+            api_key="test-key",
+            parameters=LLMParams(),
+            stream=False,
+        ),
+        tools={},
+    )
+    sent: list[Any] = []
+
+    async def capture_send(recipient, message, timeout=None):
+        sent.append(message)
+        return MagicMock()
+
+    ctx = MagicMock()
+    ctx.send = AsyncMock(side_effect=capture_send)
+
+    with patch.object(
+        proto._llm, "complete", new_callable=AsyncMock, return_value="full reply"
+    ) as mock_complete:
+        await proto.send_reply(
+            ctx, "agent1qsender", [{"role": "user", "content": "hi"}]
+        )
+
+    mock_complete.assert_awaited_once()
+    assert len(sent) == 1
+    assert isinstance(sent[0].content[0], TextContent)
+    assert sent[0].content[0].text == "full reply"
+    assert not any(isinstance(c, StartStreamContent) for m in sent for c in m.content)

--- a/python/tests/test_chat_agent_streaming.py
+++ b/python/tests/test_chat_agent_streaming.py
@@ -1,0 +1,96 @@
+"""Tests for ChatAgent streaming replies."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from uagents_core.contrib.protocols.chat import (
+    EndStreamContent,
+    StartStreamContent,
+    TextContent,
+)
+
+from uagents.experimental.chat_agent.llm import LLM, LLMConfig, LLMParams
+from uagents.experimental.chat_agent.protocol import ChatProtocol
+
+
+class _FakeStream:
+    def __init__(self, chunks: list[Any]):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        self._iter = iter(self._chunks)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def _chunk(text: str | None) -> Any:
+    return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=text))])
+
+
+@pytest.mark.asyncio
+async def test_process_stream_yields_content_deltas():
+    llm = LLM(
+        config=LLMConfig(
+            provider="openai",
+            model="test-model",
+            url="https://example.test/v1",
+            api_key="test-key",
+            parameters=LLMParams(),
+        ),
+        tools={},
+    )
+    fake = _FakeStream([_chunk("Hel"), _chunk("lo"), _chunk(None)])
+
+    with patch(
+        "uagents.experimental.chat_agent.llm.acompletion",
+        new_callable=AsyncMock,
+        return_value=fake,
+    ) as mock_complete:
+        deltas = [
+            d async for d in llm.process_stream([{"role": "user", "content": "hi"}])
+        ]
+
+    assert mock_complete.await_args.kwargs["stream"] is True
+    assert deltas == ["Hel", "lo"]
+
+
+@pytest.mark.asyncio
+async def test_send_stream_emits_start_text_end():
+    proto = ChatProtocol(
+        llm_config=LLMConfig(
+            provider="openai",
+            model="test-model",
+            url="https://example.test/v1",
+            api_key="test-key",
+            parameters=LLMParams(),
+        ),
+        tools={},
+    )
+    sent: list[Any] = []
+
+    async def capture_send(recipient, message, timeout=None):
+        sent.append(message)
+        return MagicMock()
+
+    ctx = MagicMock()
+    ctx.send = AsyncMock(side_effect=capture_send)
+
+    async def fake_stream(_messages):
+        yield "A"
+        yield "B"
+
+    with patch.object(proto._llm, "process_stream", side_effect=fake_stream):
+        await proto.send_stream(ctx, "agent1qsender", [{"role": "user", "content": "hi"}])
+
+    assert isinstance(sent[0].content[0], StartStreamContent)
+    assert isinstance(sent[1].content[0], TextContent) and sent[1].content[0].text == "A"
+    assert isinstance(sent[2].content[0], TextContent) and sent[2].content[0].text == "B"
+    assert isinstance(sent[3].content[0], EndStreamContent)
+    assert sent[0].content[0].stream_id == sent[3].content[0].stream_id

--- a/python/tests/test_chat_agent_streaming.py
+++ b/python/tests/test_chat_agent_streaming.py
@@ -5,6 +5,9 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+pytest.importorskip("litellm")
+
 from uagents_core.contrib.protocols.chat import (
     EndStreamContent,
     StartStreamContent,
@@ -31,7 +34,9 @@ class _FakeStream:
 
 
 def _chunk(text: str | None) -> Any:
-    return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=text))])
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=SimpleNamespace(content=text))]
+    )
 
 
 @pytest.mark.asyncio
@@ -87,10 +92,16 @@ async def test_send_stream_emits_start_text_end():
         yield "B"
 
     with patch.object(proto._llm, "process_stream", side_effect=fake_stream):
-        await proto.send_stream(ctx, "agent1qsender", [{"role": "user", "content": "hi"}])
+        await proto.send_stream(
+            ctx, "agent1qsender", [{"role": "user", "content": "hi"}]
+        )
 
     assert isinstance(sent[0].content[0], StartStreamContent)
-    assert isinstance(sent[1].content[0], TextContent) and sent[1].content[0].text == "A"
-    assert isinstance(sent[2].content[0], TextContent) and sent[2].content[0].text == "B"
+    assert (
+        isinstance(sent[1].content[0], TextContent) and sent[1].content[0].text == "A"
+    )
+    assert (
+        isinstance(sent[2].content[0], TextContent) and sent[2].content[0].text == "B"
+    )
     assert isinstance(sent[3].content[0], EndStreamContent)
     assert sent[0].content[0].stream_id == sent[3].content[0].stream_id


### PR DESCRIPTION
## Proposed Changes

- Stream ChatAgent plain-text replies as StartStream → TextContent deltas → EndStream instead of waiting for a full completion
- Keep tool selection non-streaming; stream only the final user-facing reply after tools run
- Include the assistant tool_calls message in the post-tool LLM follow-up so providers accept the tool result

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

