### PR TITLE
fix(core): apply server-side limit on name length

### DIFF
--- a/python/uagents-core/uagents_core/registration.py
+++ b/python/uagents-core/uagents_core/registration.py
@@ -113,7 +113,7 @@ class RegistrationRequest(BaseModel):
     name: str = Field(
         ...,
         min_length=1,
-        max_length=80,
+        max_length=32,
         description="Agent's public name",
     )
     handle: str | None = Field(


### PR DESCRIPTION
## Proposed Changes

Fixes mismatch between server (32-character limit) and client (80-character limit) on name length.

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)