### PR TITLE
docs(integration): fix broken LangChain adapter example in uagents-adapter README

### DIFF
--- a/python/uagents-adapter/README.md
+++ b/python/uagents-adapter/README.md
@@ -61,7 +61,7 @@ result = register_tool.invoke({
     "return_dict": True  # Return a dictionary instead of a string
 })
 
-print(f"Created uAgent '{result['agent_name']}' with address {result['agent_address']} on port {result['agent_port']}")
+print(f"Created uAgent '{result['name']}' with address {result['address']} on port {result['port']}")
 ```
 
 ## CrewAI Adapter


### PR DESCRIPTION
The LangChain adapter's quick-start example prints `result['agent_name']`, `result['agent_address']` and `result['agent_port']`, but `LangchainRegisterTool._run` builds its result dict with the keys `name`, `port` and `address` (see `langchain/tools.py` lines 136-140 and 154) — it never emits `agent_*` keys. So copy-pasting the documented example raises `KeyError: 'agent_name'`.

The identical print line in the **CrewAI** section (README line 117) is correct, because `CrewaiRegisterTool._run` *does* build `agent_name`/`agent_address`/`agent_port` (`crewai/tools.py` lines 635-642). The LangChain line looks like it was copied from the CrewAI example without adapting to the different return contract.

**Fix:** update the LangChain example's print line to use the keys the LangChain tool actually returns (`name`/`address`/`port`). Doc-only, one line; the CrewAI example is left untouched.

(Alternatively the two adapters' return contracts could be aligned on the code side, but this doc fix is the minimal change.)

Verified by reading both adapters' `tools.py` and both README examples on `main`.