### PR TITLE
docs(adapter): fix LangChain README example to use the tool's actual result keys

### DIFF
--- a/python/uagents-adapter/README.md
+++ b/python/uagents-adapter/README.md
@@ -61,7 +61,7 @@ result = register_tool.invoke({
     "return_dict": True  # Return a dictionary instead of a string
 })
 
-print(f"Created uAgent '{result['agent_name']}' with address {result['agent_address']} on port {result['agent_port']}")
+print(f"Created uAgent '{result['name']}' with address {result['address']} on port {result['port']}")
 ```
 
 ## CrewAI Adapter


### PR DESCRIPTION
### Problem

The LangChain adapter quickstart in `python/uagents-adapter/README.md` ends with:

```python
print(f"Created uAgent '{result['agent_name']}' with address {result['agent_address']} on port {result['agent_port']}")
```

But `LangchainRegisterTool._run()` returns the `agent_info` dict built in `src/uagents_adapter/langchain/tools.py`, whose keys are `name` (L136), `port` (L138) and `address` (set at L154) — there is no `agent_name`, `agent_address` or `agent_port` anywhere in that module. So copy-pasting the example and running it raises `KeyError: 'agent_name'` on that final line, right after the agent successfully starts.

### Evidence this is a copy-paste slip, not the intended contract

The **CrewAI** adapter section has an identical-looking print line (`README.md` a bit further down) that uses the same `agent_name`/`agent_address`/`agent_port` keys — and there it is **correct**, because `CrewaiRegisterTool` in `src/uagents_adapter/crewai/tools.py` actually builds its result dict with those `agent_*` keys. The LangChain snippet was evidently adapted from the CrewAI one without updating the key names to match `LangchainRegisterTool`'s different return shape (`name`/`address`/`port`).

### Fix

Align the LangChain example with the keys that tool actually returns — a one-line, docs-only change to the LangChain print statement:

```python
print(f"Created uAgent '{result['name']}' with address {result['address']} on port {result['port']}")
```

The CrewAI example is left untouched, since its keys are already right.

### Alternative

If you would rather keep the two adapters' documented output identical, the other direction is to make `LangchainRegisterTool` emit `agent_name`/`agent_address`/`agent_port` too, unifying both adapters' result contracts. I went with the minimal docs-side fix here since it is the safest and does not change any public return shape, but happy to switch to the code-side alignment if you prefer that.

### Verification

- `LangchainRegisterTool._run` returns `agent_info`; its keys are set to `name`/`port`/`address` in `langchain/tools.py`, with no `agent_*` keys in the file.
- The neighboring CrewAI print line uses `agent_*` and matches `crewai/tools.py`, which does define those keys — confirming the mismatch is isolated to the LangChain snippet.

Thanks for uAgents!