### PR TITLE
feat(uagents): add OrcaRouter as a named LLM provider for ChatAgent

### DIFF
--- a/python/src/uagents/experimental/chat_agent/README.md
+++ b/python/src/uagents/experimental/chat_agent/README.md
@@ -68,6 +68,8 @@ from uagents.experimental.chat_agent import ChatAgent, LLMParams, LLMConfig
 
 asione_config = LLMConfig.asi1() # default
 
+orcarouter_config = LLMConfig.orcarouter() # routes via OrcaRouter (https://www.orcarouter.ai)
+
 openai_config = LLMConfig(
     provider="openai",
     api_key="YOUR_OPENAI_API_KEY",

--- a/python/src/uagents/experimental/chat_agent/llm.py
+++ b/python/src/uagents/experimental/chat_agent/llm.py
@@ -34,6 +34,8 @@ DEFAULT_TEMPERATURE = 0.0
 DEFAULT_MAX_TOKENS = 1024
 DEFAULT_ASI1_MODEL = "asi1-mini"
 DEFAULT_ASI1_URL = "https://api.asi1.ai/v1"
+DEFAULT_ORCAROUTER_MODEL = "orcarouter/auto"
+DEFAULT_ORCAROUTER_URL = "https://api.orcarouter.ai/v1"
 DEFAULT_SYSTEM_PROMPT = (
     "You are an AI agent built on the uAgents framework and ChatProtocol. "
     "Respond clearly and concisely to the incoming request, using session history "
@@ -100,6 +102,19 @@ class LLMConfig(BaseModel):
             api_key=api_key,
             model=model,
             url=os.getenv("ASI1_BASE_URL", DEFAULT_ASI1_URL),
+            parameters=LLMParams(),
+        )
+
+    @classmethod
+    def orcarouter(cls, model: str = DEFAULT_ORCAROUTER_MODEL) -> "LLMConfig":
+        api_key = os.getenv("ORCAROUTER_API_KEY")
+        if api_key is None:
+            raise ValueError("Please set ORCAROUTER_API_KEY environment variable.")
+        return LLMConfig(
+            provider="openai",
+            api_key=api_key,
+            model=model,
+            url=os.getenv("ORCAROUTER_BASE_URL", DEFAULT_ORCAROUTER_URL),
             parameters=LLMParams(),
         )
 

--- a/python/tests/test_chat_agent_llm.py
+++ b/python/tests/test_chat_agent_llm.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from uagents.experimental.chat_agent.llm import LLMConfig
+
+
+class TestOrcaRouterConfig(unittest.TestCase):
+    def test_orcarouter_requires_api_key(self):
+        with patch.dict(os.environ, {}, clear=True), self.assertRaises(ValueError):
+            LLMConfig.orcarouter()
+
+    def test_orcarouter_defaults(self):
+        with patch.dict(os.environ, {"ORCAROUTER_API_KEY": "sk-orca-test"}, clear=True):
+            config = LLMConfig.orcarouter()
+        self.assertEqual(config.provider, "openai")
+        self.assertEqual(config.model, "orcarouter/auto")
+        self.assertEqual(config.url, "https://api.orcarouter.ai/v1")
+        self.assertEqual(config.api_key, "sk-orca-test")
+
+    def test_orcarouter_base_url_and_model_overrides(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ORCAROUTER_API_KEY": "sk-orca-test",
+                "ORCAROUTER_BASE_URL": "https://proxy.example.com/v1",
+            },
+            clear=True,
+        ):
+            config = LLMConfig.orcarouter(model="deepseek/deepseek-v4-flash")
+        self.assertEqual(config.model, "deepseek/deepseek-v4-flash")
+        self.assertEqual(config.url, "https://proxy.example.com/v1")
+        self.assertEqual(config.api_key, "sk-orca-test")


### PR DESCRIPTION
This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing `asi1` provider is wired, so `LLMConfig.orcarouter()` joins `LLMConfig.asi1()` as a first-class factory and the model/config docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Proposed Changes

- `python/src/uagents/experimental/chat_agent/llm.py` — add `LLMConfig.orcarouter()` factory mirroring `asi1()`: reads `ORCAROUTER_API_KEY` (required), defaults to `https://api.orcarouter.ai/v1` and model `orcarouter/auto`, both overridable via `ORCAROUTER_BASE_URL` and the `model` argument.
- `python/src/uagents/experimental/chat_agent/README.md` — document `LLMConfig.orcarouter()` in the LLM Configuration example.
- `python/tests/test_chat_agent_llm.py` (new) — 3 unit tests covering the missing-key error, defaults, and base_url/model overrides.

## Linked Issues

None.

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [x] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [x] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Verification

- `uv run ruff check` and `uv run ruff format --check`: clean on all changed files.
- `uv run pytest`: **110 passed, 0 failed** (includes the 3 new orcarouter tests).
- Live test with a real OrcaRouter key: `LLMConfig.orcarouter()` + `LLM.complete()` returns `PONG` via `orcarouter/auto`.
