### PR TITLE
fix(uagents): avoid duplicate registration transactions

### DIFF
--- a/python/src/uagents/network.py
+++ b/python/src/uagents/network.py
@@ -97,6 +97,18 @@ class BroadcastTimeoutError(RuntimeError):
         super().__init__("Broadcast timeout error")
 
 
+class PendingRegistrationTransactionError(RuntimeError):
+    """Raised when a registration transaction was broadcast but is still pending."""
+
+    def __init__(self, tx_hash: str, timeout_height: int):
+        self.tx_hash = tx_hash
+        self.timeout_height = timeout_height
+        super().__init__(
+            "Registration transaction is still pending "
+            f"(hash={tx_hash}, timeout_height={timeout_height})"
+        )
+
+
 class AlmanacContractRecord(AgentInfo):
     contract_address: str
     sender_address: str
@@ -547,12 +559,17 @@ class AlmanacContract(LedgerContract):
         if tx is None:
             raise BroadcastTimeoutError()
 
-        status: TxResponse = await wait_for_tx_to_complete(
-            tx_hash=tx.tx_hash,
-            ledger=ledger,
-            poll_retries=poll_retries,
-            poll_retry_delay=poll_retry_delay,
-        )
+        try:
+            status: TxResponse = await wait_for_tx_to_complete(
+                tx_hash=tx.tx_hash,
+                ledger=ledger,
+                poll_retries=poll_retries,
+                poll_retry_delay=poll_retry_delay,
+            )
+        except QueryTimeoutError as ex:
+            raise PendingRegistrationTransactionError(
+                tx.tx_hash, timeout_height
+            ) from ex
         if status.code != 0:
             raise RuntimeError(
                 f"Registration transaction failed ({status.code}): {status.hash})"
@@ -648,12 +665,17 @@ class AlmanacContract(LedgerContract):
         if tx is None:
             raise BroadcastTimeoutError()
 
-        status: TxResponse = await wait_for_tx_to_complete(
-            tx_hash=tx.tx_hash,
-            ledger=ledger,
-            poll_retries=poll_retries,
-            poll_retry_delay=poll_retry_delay,
-        )
+        try:
+            status: TxResponse = await wait_for_tx_to_complete(
+                tx_hash=tx.tx_hash,
+                ledger=ledger,
+                poll_retries=poll_retries,
+                poll_retry_delay=poll_retry_delay,
+            )
+        except QueryTimeoutError as ex:
+            raise PendingRegistrationTransactionError(
+                tx.tx_hash, timeout_height
+            ) from ex
         if status.code != 0:
             raise RuntimeError(
                 f"Registration transaction failed ({status.code}): {status.hash})"

--- a/python/src/uagents/registration.py
+++ b/python/src/uagents/registration.py
@@ -3,6 +3,7 @@ import contextlib
 import json
 import logging
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -35,6 +36,7 @@ from uagents.network import (
     AlmanacContract,
     AlmanacContractRecord,
     InsufficientFundsError,
+    PendingRegistrationTransactionError,
     RetryDelayFunc,
     add_testnet_funds,
     default_exp_backoff,
@@ -48,6 +50,12 @@ class AgentRegistrationAttestationBatch(BaseModel):
 
 class AgentStatusUpdate(VerifiableModel):
     is_active: bool
+
+
+@dataclass
+class PendingRegistrationTransaction:
+    tx_hash: str
+    timeout_height: int
 
 
 def coerce_metadata_to_str(
@@ -248,6 +256,8 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
         self._last_funds_warning_logged: datetime | None = None
         self._timeout_blocks = timeout_blocks
         self._tx_fee = tx_fee
+        self._pending_registration: PendingRegistrationTransaction | None = None
+        self._registration_lock = asyncio.Lock()
 
     @property
     def last_successful_registration(self) -> datetime | None:
@@ -298,9 +308,10 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
         the registration data has changed.
         """
         try:
-            await self._register_on_almanac_contract(
-                agent_identifier, identity, protocols, endpoints
-            )
+            async with self._registration_lock:
+                await self._register_on_almanac_contract(
+                    agent_identifier, identity, protocols, endpoints
+                )
         except grpc.RpcError as e:
             if is_ledger_rpc_unavailable(e):
                 self._logger.warning(
@@ -318,6 +329,9 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
         protocols: list[str],
         endpoints: list[AgentEndpoint],
     ) -> None:
+        if self._has_valid_pending_registration():
+            return
+
         _, _, agent_address = parse_identifier(agent_identifier)
 
         if (
@@ -377,14 +391,54 @@ class LedgerBasedRegistrationPolicy(AgentRegistrationPolicy):
                 self._logger.info("Registering on almanac contract...complete")
                 self._last_successful_registration = datetime.now()
 
+            except PendingRegistrationTransactionError as e:
+                self._pending_registration = PendingRegistrationTransaction(
+                    e.tx_hash, e.timeout_height
+                )
+                self._logger.info(
+                    "Registration transaction is pending; waiting before retrying"
+                )
             except RuntimeError as e:
                 self._logger.warning(
                     "Registering on almanac contract...failed (will retry later)"
                 )
                 self._logger.debug(e)
-
         else:
             self._logger.info("Almanac contract registration is up to date!")
+
+    def _has_valid_pending_registration(self) -> bool:
+        pending = self._pending_registration
+        if pending is None:
+            return False
+
+        try:
+            status = self._ledger.query_tx(pending.tx_hash)
+        except Exception:
+            try:
+                if self._ledger.query_height() <= pending.timeout_height:
+                    return True
+            except Exception:
+                self._logger.debug(
+                    "Unable to determine whether the pending registration transaction "
+                    "has expired",
+                    exc_info=True,
+                )
+                return True
+
+            self._logger.info("Pending registration transaction expired; retrying")
+            self._pending_registration = None
+            return False
+
+        self._pending_registration = None
+        if status.code == 0:
+            self._logger.info("Pending registration transaction completed")
+            self._last_successful_registration = datetime.now()
+            return True
+
+        self._logger.warning(
+            "Pending registration transaction failed (%s); retrying", status.code
+        )
+        return False
 
     def _get_balance(self) -> int:
         return self._ledger.query_bank_balance(Address(self._wallet.address()))
@@ -440,6 +494,8 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
         self._last_successful_registration: datetime | None = None
         self._tx_fee: TxFee | None = None
         self._timeout_blocks = timeout_blocks
+        self._pending_registration: PendingRegistrationTransaction | None = None
+        self._registration_lock = asyncio.Lock()
 
     @property
     def last_successful_registration(self) -> datetime | None:
@@ -495,7 +551,8 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
 
     async def register(self) -> None:
         try:
-            await self._register_agents_on_almanac_contract()
+            async with self._registration_lock:
+                await self._register_agents_on_almanac_contract()
         except grpc.RpcError as e:
             if is_ledger_rpc_unavailable(e):
                 self._logger.warning(
@@ -507,6 +564,9 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
                 raise
 
     async def _register_agents_on_almanac_contract(self) -> None:
+        if self._has_valid_pending_registration():
+            return
+
         self._logger.info("Registering agents on Almanac contract...")
         for record in self._records:
             record.sign(self._identities[record.address])
@@ -541,11 +601,52 @@ class BatchLedgerRegistrationPolicy(BatchRegistrationPolicy):
             self._logger.info("Registering agents on Almanac contract...complete")
             self._last_successful_registration = datetime.now()
 
+        except PendingRegistrationTransactionError as e:
+            self._pending_registration = PendingRegistrationTransaction(
+                e.tx_hash, e.timeout_height
+            )
+            self._logger.info(
+                "Registration transaction is pending; waiting before retrying"
+            )
         except RuntimeError as e:
             self._logger.warning(
                 "Registering on almanac contract...failed (will retry later)"
             )
             self._logger.debug(e)
+
+    def _has_valid_pending_registration(self) -> bool:
+        pending = self._pending_registration
+        if pending is None:
+            return False
+
+        try:
+            status = self._ledger.query_tx(pending.tx_hash)
+        except Exception:
+            try:
+                if self._ledger.query_height() <= pending.timeout_height:
+                    return True
+            except Exception:
+                self._logger.debug(
+                    "Unable to determine whether the pending registration transaction "
+                    "has expired",
+                    exc_info=True,
+                )
+                return True
+
+            self._logger.info("Pending registration transaction expired; retrying")
+            self._pending_registration = None
+            return False
+
+        self._pending_registration = None
+        if status.code == 0:
+            self._logger.info("Pending registration transaction completed")
+            self._last_successful_registration = datetime.now()
+            return True
+
+        self._logger.warning(
+            "Pending registration transaction failed (%s); retrying", status.code
+        )
+        return False
 
 
 class DefaultRegistrationPolicy(AgentRegistrationPolicy):

--- a/python/tests/test_flakey_network_registration.py
+++ b/python/tests/test_flakey_network_registration.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import unittest
@@ -73,6 +74,7 @@ class FakeLedgerClient:
         self.network_config = NetworkConfig.fetchai_mainnet()
 
         self._broadcast_failure_count = 0
+        self._broadcast_count = 0
         self._rpc_query_failure_count = 0
         self._query_failure_count = 0
         self._height = 1000
@@ -84,6 +86,10 @@ class FakeLedgerClient:
     @broadcast_failure_count.setter
     def broadcast_failure_count(self, value: int):
         self._broadcast_failure_count = value
+
+    @property
+    def broadcast_count(self) -> int:
+        return self._broadcast_count
 
     @property
     def rpc_query_failure_count(self) -> int:
@@ -122,6 +128,7 @@ class FakeLedgerClient:
             self._broadcast_failure_count -= 1
             print("Broadcast failure", self._broadcast_failure_count)
             raise BroadcastError("not-a-real-hash", "not-a-real-tx-log")
+        self._broadcast_count += 1
         return FakeSubmittedTx()
 
     def query_tx(self, tx_hash: str) -> TxResponse:
@@ -264,6 +271,49 @@ class FlakeyNetworkRegistrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.ledger.query_failure_count, 1)
         self.assertIsNone(self.policy.last_successful_registration)
 
+    async def test_waits_for_pending_registration_before_timeout_height(self):
+        self.ledger.query_failure_count = 20
+        self.policy.poll_retries = 1
+        self.policy.poll_retry_delay = zero_retry_delay
+
+        await self.policy.register(self.identity.address, self.identity, [], [])
+        await self.policy.register(self.identity.address, self.identity, [], [])
+
+        self.assertEqual(self.ledger.broadcast_count, 1)
+
+        self.ledger._height += self.policy._timeout_blocks
+        await self.policy.register(self.identity.address, self.identity, [], [])
+
+        self.assertEqual(self.ledger.broadcast_count, 1)
+
+        self.ledger._height += 1
+        await self.policy.register(self.identity.address, self.identity, [], [])
+
+        self.assertEqual(self.ledger.broadcast_count, 2)
+
+    async def test_confirms_pending_registration_without_rebroadcasting(self):
+        self.ledger.query_failure_count = 1
+        self.policy.poll_retries = 1
+        self.policy.poll_retry_delay = zero_retry_delay
+
+        await self.policy.register(self.identity.address, self.identity, [], [])
+        await self.policy.register(self.identity.address, self.identity, [], [])
+
+        self.assertEqual(self.ledger.broadcast_count, 1)
+        self.assertIsNotNone(self.policy.last_successful_registration)
+
+    async def test_concurrent_registration_attempts_broadcast_once(self):
+        self.ledger.query_failure_count = 20
+        self.policy.poll_retries = 1
+        self.policy.poll_retry_delay = zero_retry_delay
+
+        await asyncio.gather(
+            self.policy.register(self.identity.address, self.identity, [], []),
+            self.policy.register(self.identity.address, self.identity, [], []),
+        )
+
+        self.assertEqual(self.ledger.broadcast_count, 1)
+
 
 class FlakeyBatchNetworkRegistrationTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
@@ -370,3 +420,43 @@ class FlakeyBatchNetworkRegistrationTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(self.ledger.query_failure_count, 1)
         self.assertIsNone(self.policy.last_successful_registration)
+
+    async def test_waits_for_pending_registration_before_timeout_height(self):
+        self.ledger.query_failure_count = 20
+        self.policy.poll_retries = 1
+        self.policy.poll_retry_delay = zero_retry_delay
+
+        await self.policy.register()
+        await self.policy.register()
+
+        self.assertEqual(self.ledger.broadcast_count, 1)
+
+        self.ledger._height += self.policy._timeout_blocks
+        await self.policy.register()
+
+        self.assertEqual(self.ledger.broadcast_count, 1)
+
+        self.ledger._height += 1
+        await self.policy.register()
+
+        self.assertEqual(self.ledger.broadcast_count, 2)
+
+    async def test_confirms_pending_registration_without_rebroadcasting(self):
+        self.ledger.query_failure_count = 1
+        self.policy.poll_retries = 1
+        self.policy.poll_retry_delay = zero_retry_delay
+
+        await self.policy.register()
+        await self.policy.register()
+
+        self.assertEqual(self.ledger.broadcast_count, 1)
+        self.assertIsNotNone(self.policy.last_successful_registration)
+
+    async def test_concurrent_registration_attempts_broadcast_once(self):
+        self.ledger.query_failure_count = 20
+        self.policy.poll_retries = 1
+        self.policy.poll_retry_delay = zero_retry_delay
+
+        await asyncio.gather(self.policy.register(), self.policy.register())
+
+        self.assertEqual(self.ledger.broadcast_count, 1)


### PR DESCRIPTION
## Summary
- retain a broadcast registration transaction while it is still valid by timeout height
- avoid rebroadcasting registration transactions until the pending transaction succeeds, fails, or expires
- serialize concurrent registration attempts for both single-agent and batch registration
- add regression coverage for pending transactions, the exact expiry boundary, delayed confirmations, and concurrent calls

Fixes #705.

## Testing
- python -m pytest tests/test_flakey_network_registration.py tests/test_registration.py -q (26 passed)
- python -m pytest tests -q --disable-warnings --maxfail=10 (107 passed; 6 ledger-backed tests could not connect from this sandbox)
- python -m ruff check src/uagents/network.py src/uagents/registration.py tests/test_flakey_network_registration.py`n- python -m ruff format --check src/uagents/network.py src/uagents/registration.py tests/test_flakey_network_registration.py`n
## Compatibility and risk
No wire-format, protocol digest, signing, fee, or public configuration changes. If transaction status or height cannot be queried, the policy conservatively waits rather than risking a duplicate broadcast.