### PR TITLE
fix(experimental): enforce local dialogue session expiry

### DIFF
--- a/python/src/uagents/experimental/dialogues/__init__.py
+++ b/python/src/uagents/experimental/dialogues/__init__.py
@@ -3,7 +3,7 @@
 import functools
 import warnings
 from collections.abc import Awaitable, Callable
-from datetime import datetime, timedelta
+from time import time
 from typing import Any
 from uuid import UUID
 
@@ -11,12 +11,47 @@ from uagents_core.models import ErrorMessage
 from uagents_core.types import DeliveryStatus, JsonStr, MsgStatus
 
 from uagents import Context, Model, Protocol
+from uagents.context import ExternalContext
 from uagents.storage import KeyValueStore, StorageAPI
 
 DEFAULT_SESSION_TIMEOUT_IN_SECONDS = 60
 TARGET_UUID_VERSION = 4
 
 MessageCallback = Callable[["Context", str, Any], Awaitable[None]]
+
+
+class _DialogueContext(ExternalContext):
+    """Guard handler sends before dispatch, including raw and request/reply sends."""
+
+    def __init__(self, base: Context, expires_at: float | None):
+        self.__dict__ = base.__dict__.copy()
+        self._dialogue_expires_at = expires_at
+
+    def is_expired(self) -> bool:
+        return (
+            self._dialogue_expires_at is not None
+            and time() >= self._dialogue_expires_at
+        )
+
+    async def send_raw(
+        self,
+        destination: str,
+        message_schema_digest: str,
+        message_body: JsonStr,
+        *args,
+        **kwargs,
+    ) -> MsgStatus:
+        if self.is_expired():
+            return MsgStatus(
+                status=DeliveryStatus.FAILED,
+                detail="Dialogue session expired",
+                destination=destination,
+                endpoint="",
+                session=self.session,
+            )
+        return await super().send_raw(
+            destination, message_schema_digest, message_body, *args, **kwargs
+        )
 
 
 class Node:
@@ -141,6 +176,13 @@ class Dialogue(Protocol):
         messages that were exchanged between two participants.
     - Sessions will automatically be deleted after a certain amount of time.
     - Access to the dialogue history through ctx.dialogue (see Context class).
+
+    ``timeout`` is a local idle timeout in seconds since the last recorded
+    message. Zero disables expiry. Incoming messages and sends through the
+    handler's context are rejected once the deadline is reached, even when
+    periodic cleanup is disabled. A handler already running is not cancelled,
+    but its context rejects further sends after expiry. Expired history is
+    removed during cleanup and on restart. Peers do not negotiate this timeout.
     """
 
     def __init__(
@@ -181,9 +223,14 @@ class Dialogue(Protocol):
             self._states = {
                 session_id: session[-1]["schema_digest"]
                 for session_id, session in self._sessions.items()
+                if session
             }
 
         super().__init__(name=self._name, version=version)
+
+        for session_id in list(self._sessions):
+            if self.is_expired(session_id):
+                self.cleanup_conversation(session_id)
 
         # if a model exists for an edge, register the handler automatically
         self._auto_add_message_handler()
@@ -390,16 +437,29 @@ class Dialogue(Protocol):
         @functools.wraps(edge.func)
         async def handler(ctx: Context, sender: str, message: type[Model]):
             # validate message first then execute handlers, finally update state
+            if ctx.session and self.is_expired(ctx.session):
+                return await ctx.send(
+                    sender, ErrorMessage(error="Dialogue session expired")
+                )
             if not self._pre_handle_hook(ctx, sender, message):
                 return await ctx.send(
                     sender,
                     ErrorMessage(error=f"Unexpected message in dialogue: {message}"),
                 )
 
+            ctx = _DialogueContext(ctx, self._session_deadline(ctx.session))
             if edge.efunc:
                 await edge.efunc(ctx, sender, message)
             result = await edge.func(ctx, sender, message)  # type: ignore
 
+            if ctx.is_expired():
+                return MsgStatus(
+                    status=DeliveryStatus.FAILED,
+                    detail="Dialogue session expired",
+                    destination=sender,
+                    endpoint="",
+                    session=ctx.session,
+                )
             if not self._post_handle_hook(ctx, sender, message):
                 return MsgStatus(
                     status=DeliveryStatus.FAILED,
@@ -443,8 +503,24 @@ class Dialogue(Protocol):
 
     def cleanup_conversation(self, session_id: UUID) -> None:
         """Removes all messages related with the given session from the dialogue instance."""
-        self._sessions.pop(session_id)
+        self._sessions.pop(session_id, None)
+        self._states.pop(session_id, None)
         self._remove_session_from_storage(session_id)
+
+    def _session_deadline(self, session_id: UUID) -> float | None:
+        session = self._sessions.get(session_id)
+        if not session or session[-1]["timeout"] <= 0:
+            return None
+        return session[-1]["timestamp"] + session[-1]["timeout"]
+
+    def is_expired(self, session_id: UUID) -> bool:
+        """Check the persisted idle deadline; zero timeout means no expiry.
+
+        Cleanup frequency does not affect validity. Unknown and empty sessions
+        have no deadline. Deadlines are local, not negotiated with the peer.
+        """
+        deadline = self._session_deadline(session_id)
+        return deadline is not None and time() >= deadline
 
     def add_message(
         self,
@@ -468,7 +544,7 @@ class Dialogue(Protocol):
                 "sender": sender,
                 "receiver": receiver,
                 "message_content": content,
-                "timestamp": datetime.timestamp(datetime.now()),
+                "timestamp": time(),
                 "timeout": self._timeout,
                 **kwargs,
             }
@@ -521,6 +597,8 @@ class Dialogue(Protocol):
         Returns:
             bool: True if the message is valid, False otherwise.
         """
+        if self.is_expired(session_id):
+            return False
         if session_id not in self._sessions or len(self._sessions[session_id]) == 0:
             return self.is_starter(msg_digest)
 
@@ -655,6 +733,17 @@ class Dialogue(Protocol):
                 "A dialogue can only be started with the specified starting message"
             )
 
+        if ctx.session and self.is_expired(ctx.session):
+            return [
+                MsgStatus(
+                    status=DeliveryStatus.FAILED,
+                    detail="Dialogue session expired",
+                    destination=destination,
+                    endpoint="",
+                    session=ctx.session,
+                )
+            ]
+
         status_list: list[MsgStatus] = []
 
         if destination.startswith("proto:"):
@@ -687,13 +776,12 @@ class Dialogue(Protocol):
         Initialise the cleanup task.
 
         Deletes sessions that have not been used for a certain amount of time.
-        The task runs every second so the configured timeout is currently
-        measured in seconds as well (interval time * timeout parameter).
+        Timeout is measured in seconds since the last recorded message.
         Sessions with 0 as timeout will never be deleted.
 
         *Important*:
-        - setting the interval above 1 will act as a multiplier
-        - setting it to 0 will disable the cleanup task
+        - the interval only controls how often expired history is removed
+        - setting it to 0 disables cleanup, but does not disable expiry checks
         """
         if interval == 0:
             return
@@ -701,14 +789,8 @@ class Dialogue(Protocol):
         @self.on_interval(interval)
         async def cleanup_dialogue(_ctx: Context):
             mark_for_deletion = []
-            for session_id, session in self._sessions.items():
-                timeout = session[-1]["timeout"]
-                if (
-                    timeout > 0
-                    and datetime.fromtimestamp(session[-1]["timestamp"])
-                    + timedelta(seconds=timeout)
-                    < datetime.now()
-                ):
+            for session_id in self._sessions:
+                if self.is_expired(session_id):
                     mark_for_deletion.append(session_id)
             if mark_for_deletion:
                 for session_id in mark_for_deletion:

--- a/python/tests/test_dialogues.py
+++ b/python/tests/test_dialogues.py
@@ -1,0 +1,233 @@
+"""Local dialogue expiry is independent of cleanup scheduling."""
+
+from copy import deepcopy
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from uagents_core.types import DeliveryStatus
+
+from uagents import Model
+from uagents.context import ExternalContext
+from uagents.experimental.dialogues import Dialogue, Edge, Node, _DialogueContext
+
+
+class Start(Model):
+    pass
+
+
+class Reply(Model):
+    pass
+
+
+class MemoryStore:
+    def __init__(self):
+        self.data = {}
+
+    def get(self, key):
+        return deepcopy(self.data.get(key))
+
+    def set(self, key, value):
+        self.data[key] = deepcopy(value)
+
+
+@pytest.fixture
+def clock():
+    with patch("uagents.experimental.dialogues.time", return_value=1000.0) as mocked:
+        # Also control the upstream implementation's clock for regression checks.
+        class ClockDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return cls.fromtimestamp(mocked.return_value, tz)
+
+        with patch(
+            "uagents.experimental.dialogues.datetime", ClockDatetime, create=True
+        ):
+            yield mocked
+
+
+def make_dialogue(store=None, timeout=60, interval=1):
+    first, last = Node("first", "First"), Node("last", "Last")
+    start = Edge("start", "Start", None, first)
+    reply = Edge("reply", "Reply", first, last)
+    start.model, reply.model = Start, Reply
+
+    async def noop(ctx, sender, message):
+        pass
+
+    start.func = reply.func = noop
+    return Dialogue(
+        "test",
+        storage=store or MemoryStore(),
+        nodes=[first, last],
+        edges=[start, reply],
+        timeout=timeout,
+        cleanup_interval=interval,
+    )
+
+
+def seed(dialogue):
+    session = uuid4()
+    digest = Model.build_schema_digest(Start)
+    dialogue.add_message(session, "Start", digest, "alice", "bob", "{}")
+    dialogue.update_state(digest, session)
+    return session
+
+
+@pytest.mark.parametrize("interval", [0, 1, 30])
+def test_expiry_boundary_independent_of_cleanup(clock, interval):
+    dialogue = make_dialogue(interval=interval)
+    session = seed(dialogue)
+    digest = Model.build_schema_digest(Reply)
+    clock.return_value = 1059
+    assert dialogue.is_valid_message(session, digest)
+    clock.return_value = 1060
+    assert not dialogue.is_valid_message(session, digest)
+    assert session in dialogue._sessions
+
+
+def test_restart_preserves_deadline_and_removes_expired_state(clock):
+    store = MemoryStore()
+    dialogue = make_dialogue(store)
+    session = seed(dialogue)
+    clock.return_value = 1059
+    restored = make_dialogue(store)
+    assert restored.is_valid_message(session, Model.build_schema_digest(Reply))
+    clock.return_value = 1060
+    restored = make_dialogue(store)
+    assert session not in restored._sessions
+    assert restored.get_current_state(session) == ""
+    assert str(session) not in store.get("test")
+
+
+def test_unlimited_and_empty_sessions_survive_restart(clock):
+    store = MemoryStore()
+    dialogue = make_dialogue(store, timeout=0)
+    session = seed(dialogue)
+    empty = uuid4()
+    store.set("test", store.get("test") | {str(empty): []})
+    clock.return_value = 1000000
+    restored = make_dialogue(store, timeout=0)
+    assert not restored.is_expired(session)
+    assert restored.is_valid_message(session, Model.build_schema_digest(Reply))
+    assert empty in restored._sessions
+
+
+@pytest.mark.asyncio
+async def test_cleanup_is_complete_repeatable_and_handles_empty_sessions(clock):
+    dialogue = make_dialogue()
+    session = seed(dialogue)
+    empty = uuid4()
+    dialogue._add_session(empty)
+    clock.return_value = 1060
+    await dialogue.intervals[0][0](None)
+    dialogue.cleanup_conversation(session)
+    assert session not in dialogue._sessions
+    assert dialogue.get_current_state(session) == ""
+    assert str(session) not in dialogue._storage.get("test")
+    assert empty in dialogue._sessions
+
+
+@pytest.mark.asyncio
+async def test_expired_inbound_never_runs_handler(clock):
+    dialogue = make_dialogue()
+    session = seed(dialogue)
+    handler = AsyncMock()
+    wrapped = dialogue._on_state_transition("reply", Reply)(handler)
+    ctx = SimpleNamespace(session=session, send=AsyncMock())
+    clock.return_value = 1060
+    await wrapped(ctx, "alice", Reply())
+    handler.assert_not_awaited()
+    assert ctx.send.call_args.args[1].error == "Dialogue session expired"
+
+
+@pytest.mark.asyncio
+async def test_handler_crossing_deadline_cannot_send_or_restore_cleaned_session(clock):
+    dialogue = make_dialogue()
+    session = uuid4()
+    ctx = object.__new__(ExternalContext)
+    ctx._session = session
+    ctx._agent = SimpleNamespace(address="bob")
+    ctx._protocol = ("test", None)
+    ctx._queries = {}
+    ctx._outbound_messages = {}
+
+    @dialogue._on_state_transition("start", Start)
+    async def handler(context, sender, message):
+        clock.return_value = 1060
+        await dialogue.intervals[0][0](None)
+        status = await context.send(sender, Reply())
+        assert status.status == DeliveryStatus.FAILED
+        assert status.detail == "Dialogue session expired"
+
+    with patch.object(ExternalContext, "send_raw", new_callable=AsyncMock) as dispatch:
+        status = await handler(ctx, "alice", Start())
+    dispatch.assert_not_awaited()
+    assert status.detail == "Dialogue session expired"
+    assert session not in dialogue._sessions
+
+
+@pytest.mark.asyncio
+async def test_send_guard_allows_active_and_unlimited_sessions(clock):
+    base = object.__new__(ExternalContext)
+    base._session = uuid4()
+    with patch.object(ExternalContext, "send_raw", new_callable=AsyncMock) as dispatch:
+        await _DialogueContext(base, 1060).send_raw("alice", "digest", "{}")
+        clock.return_value = 2000
+        await _DialogueContext(base, None).send_raw("alice", "digest", "{}")
+    assert dispatch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_expired_raw_send_never_dispatches(clock):
+    base = object.__new__(ExternalContext)
+    base._session = uuid4()
+    clock.return_value = 1060
+    with patch.object(ExternalContext, "send_raw", new_callable=AsyncMock) as dispatch:
+        status = await _DialogueContext(base, 1060).send_raw("alice", "digest", "{}")
+    dispatch.assert_not_awaited()
+    assert status.status == DeliveryStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_start_cannot_reuse_expired_session(clock):
+    dialogue = make_dialogue()
+    session = seed(dialogue)
+    ctx = SimpleNamespace(session=session, send=AsyncMock(), broadcast=AsyncMock())
+    clock.return_value = 1060
+    statuses = await dialogue.start_dialogue(ctx, "agent-test", Start())
+    assert statuses[0].detail == "Dialogue session expired"
+    ctx.send.assert_not_awaited()
+    ctx.broadcast.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_handler_reply_updates_shared_history_and_idle_deadline(clock):
+    dialogue = make_dialogue()
+    session = uuid4()
+    ctx = object.__new__(ExternalContext)
+    ctx._session = session
+    ctx._agent = SimpleNamespace(address="bob")
+    ctx._protocol = ("test", None)
+    ctx._queries = {}
+    ctx._outbound_messages = {}
+
+    @dialogue._on_state_transition("start", Start)
+    async def handler(context, sender, message):
+        clock.return_value = 1030
+        await context.send(sender, Reply())
+
+    async def dispatch(destination, message_schema_digest, message_body, **kwargs):
+        ctx._outbound_messages[destination] = [(message_body, message_schema_digest)]
+
+    with patch.object(ExternalContext, "send_raw", side_effect=dispatch):
+        await handler(ctx, "alice", Start())
+    assert len(dialogue.get_conversation(session)) == 2
+    assert dialogue.is_finished(session)
+    assert "alice" in ctx.outbound_messages
+    clock.return_value = 1089
+    assert not dialogue.is_expired(session)
+    clock.return_value = 1090
+    assert dialogue.is_expired(session)


### PR DESCRIPTION
## Proposed Changes

An expired dialogue currently accepts the next message until periodic cleanup runs, including after restart. A handler can also send a reply after the session expires because reply validation runs after sending.

- Check the persisted local idle deadline before accepting incoming messages and before handler-context sends, returning an explicit expiry failure.
- Retain the handler's deadline so cleanup during a running handler cannot allow a late send or recreate expired history.
- Remove expired sessions on restart and clear both history and state during idempotent cleanup; tolerate empty session histories.
- Preserve the existing storage format and unlimited (`timeout=0`) sessions. Document that cleanup frequency does not multiply the timeout or disable expiry enforcement.
- Add 12 deterministic tests covering expiry boundaries, restart, cleanup, late sends, and normal reply/history behavior.

## Linked Issues

Partial implementation of #413. This addresses local expiry enforcement and cleanup. Peer timeout synchronization remains unresolved; this PR does not close the issue or introduce wire-format or protocol-digest changes.

## Types of changes

- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [x] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

Validation: full pytest suite, targeted Ruff lint and formatting checks, and `git diff --check`. Four regression cases fail against the upstream dialogue implementation (expiry checks at three cleanup intervals and cleanup with an empty session).

Documentation changes are source docstrings; the API documentation generator was not run.

Behavioral scope: expiry is enforced even when periodic cleanup is disabled. Running handlers are not cancelled, but subsequent sends through their supplied context are rejected after the deadline. After history is removed, the existing unknown-session behavior applies; no persistent expired-session tombstones or peer timeout negotiation are added.
