### PR TITLE
docs(experimental): propose dialogue timeout negotiation with peer simulation

### DIFF
--- a/proposals/dialogue-timeout/INTEGRATION.md
+++ b/proposals/dialogue-timeout/INTEGRATION.md
@@ -1,0 +1,59 @@
+# Why this is a draft and what remains
+
+## Current situation
+
+Issue #413 combines local expiry enforcement with unsynchronized peer timeouts.
+PR #942 addresses local enforcement, cleanup, and restart behavior. This draft
+provides an independent proposal and executable model for the remaining peer
+negotiation problem. No production peer-synchronization fix is applied here.
+
+It remains a draft because the protocol choices need maintainer review and the
+simulation bypasses real uAgents contexts, identity validation, serialization,
+transport, scheduling, and durable storage. Those layers can invalidate assumptions
+that hold in an in-memory model. Simulation success alone cannot establish that
+real application messages are blocked or accepted at the correct time.
+
+The proposed guarantee is deliberately limited: within the stated drift and
+state-retention assumptions, an acknowledged initiator lease expires no later
+than the corresponding responder lease. It does not guarantee simultaneous expiry,
+delivery near a deadline, or instantaneous detection of a remote crash.
+
+## Decisions requiring review
+
+- Choose explicit renewable leases versus the existing activity-based idle
+  timeout, and determine which application activity should request renewal.
+- Agree on initiator authority, control-message schemas, protocol version/digest,
+  authenticated peer/session binding, and capability negotiation.
+- Define unsupported and silent peer behavior, unlimited timeout semantics,
+  drift bounds, handshake deadlines, and retry limits.
+- Decide whether fresh-session recovery is acceptable after restart. Seamless
+  recovery requires additional durable state and an authenticated recovery exchange.
+- Define replay-record retention and cache bounds, expiry errors, and handling
+  of application side effects when a connection or session is lost.
+
+## Real-peer implementation and acceptance tests
+
+| Required work | Acceptance evidence |
+| --- | --- |
+| Wire models and identity checks | Two real uAgents negotiate the same policy using serialized, authenticated control messages; mismatched peer/session/version and malformed inputs are rejected. |
+| Runtime guards | Both application send and receive paths enforce the negotiated lease, including handlers waiting across expiry and messages delivered near or after expiry. |
+| Transport coverage | Demonstrate both local dispatch and separate-process transport, with delays, dropped acknowledgments, duplicates, reordered messages, and endpoint failures. |
+| Compatibility | Exercise a real legacy peer and an upgraded peer; show an explicit refusal or deliberately selected legacy mode, without claiming synchronized fallback. |
+| Clock behavior | Test supported drift assumptions and define behavior for unsupported jumps or suspend/resume conditions. |
+| Recovery | Restart each real process independently and together; test replayed traffic, durable checkpoint loading, interrupted writes, and fresh-session recovery. |
+| Operational bounds | Verify bounded retry/caches, invalid timeout handling, concurrent sessions, cancellation, and application errors without accidental session revival. |
+| Regression coverage | Run relevant context/protocol tests and the full suite on the integration branch; retain the deterministic model tests and document supported environments. |
+
+These are pending criteria, not completed tests. The exact implementation may
+change following maintainer review.
+
+## How to advance the work
+
+1. Review this draft's model and limitations and agree on the protocol decisions.
+2. Decide whether to merge the proposal as documentation only or keep it as a
+   reference for a separate implementation PR. A documentation merge would not
+   resolve #413 or deliver synchronization to users.
+3. Implement and run the real-peer acceptance tests above on a separate runtime
+   branch, coordinating with the local guards in #942.
+4. Publish implementation results and compatibility notes before representing the
+   synchronization work as production-ready or asking to close #413.

--- a/proposals/dialogue-timeout/README.md
+++ b/proposals/dialogue-timeout/README.md
@@ -1,0 +1,151 @@
+# Dialogue timeout negotiation experiment
+
+This standalone simulation explores the peer-synchronization part of
+[fetchai/uAgents #413](https://github.com/fetchai/uAgents/issues/413).
+It is not integrated with uAgents and does not change PR #942. No network,
+blockchain transactions, dependencies, or real agents are required.
+
+## Relationship to the existing fix
+
+Issue #413 describes two problems: local expiry is not enforced by the dialogue
+engine, and peers do not agree on their timeout policy.
+
+[PR #942](https://github.com/fetchai/uAgents/pull/942) implements the first part:
+it checks local expiry before incoming handlers and handler-context sends,
+removes expired persisted sessions on restart, and clears history and state
+during cleanup. That change was validated with 119 passing tests at submission.
+It does not synchronize peer deadlines.
+
+This proposal covers the second part with an independent executable model.
+It contains no production runtime changes and does not incorporate #942's code.
+The proposed lease protocol is not an applied production fix and does not close
+#413. The two-agent tests below use simulated peers, not real uAgents instances.
+
+## Run
+
+From this directory, using Python 3.10 or newer:
+
+```powershell
+python -m unittest -v
+python lease_simulation.py
+```
+
+
+
+## Proposed semantics
+
+Use an opt-in, versioned control protocol for finite renewable session leases.
+This is a candidate design, not a negotiated standard or a production fix.
+
+1. The initiator sends an offer containing a fresh session ID, version, sequence
+   zero, and its maximum lease duration. It records its local send time.
+2. The responder selects the smaller positive duration of the two preferences,
+   records a local deadline, and acknowledges the duration and sequence.
+3. The initiator accepts a matching acknowledgment only while the conservative
+   deadline computed from its original send time is still in the future.
+4. The initiator can request renewal before its acknowledged lease expires.
+   Only one request is outstanding. Both sides retain the chosen duration.
+   The responder must still be active; the initiator must receive the reply
+   before both its old deadline and its proposed new deadline.
+5. Duplicate requests return the cached acknowledgment without extending the
+   deadline again. Unrelated sessions and stale acknowledgment sequences are
+   ignored. A late message cannot revive an expired lease.
+
+The virtual scheduler controls delivery delay and acknowledgment loss. Each
+peer has a separate clock with its own offset and constant rate. The scheduler's
+global time is for simulation only; peers do not exchange or rely on it.
+
+## What the timing rule guarantees
+
+Let the agreed duration be L and the shared maximum fractional clock drift be d.
+The initiator's local deadline is `request_send_time + L * (1-d)`; the responder's
+is `request_receive_time + L * (1+d)`. Clock offsets can be arbitrary.
+
+Assuming honest peers, nonnegative network delay, no clock jumps, clock rates
+within `[1-d, 1+d]`, and no restart or loss of responder state, an acknowledged
+initiator lease ends no later in real time than the corresponding responder
+lease. The initiator's longest real interval is L; the responder's shortest
+real interval is L, beginning no earlier than request delivery.
+
+The tests exercise all nine endpoint/nominal clock-rate combinations at three
+network delays (27 cases within one test). The default 1% drift margin is an
+illustrative simulation parameter, not a recommended production setting.
+
+This does **not** promise simultaneous expiry, mutual knowledge of acceptance,
+or successful delivery of an application message sent just before expiry. A
+responder may retain state longer after a lost acknowledgment. A crash can
+invalidate a responder's state before the initiator learns about it. Explicit
+tests preserve these limitations rather than hiding them.
+
+## Restart and legacy behavior
+
+`checkpoint()` serializes preferences and previously used session IDs to JSON.
+`restore()` reconstructs a peer without reusing any process-local lease deadline.
+Both peers must negotiate a fresh session after restart. Old-session offers and
+renewals are rejected. The tests perform a JSON round trip and fresh negotiation.
+Production requires durable, atomic recording of session IDs before acceptance;
+this in-memory prototype does not simulate disk failure or atomicity.
+
+A protocol-aware peer that does not support this version explicitly refuses.
+A silent older peer never activates the initiator's lease. There is no automatic
+fallback claiming synchronization. Production needs a bounded handshake wait
+with a user-visible failure and an explicit choice to use legacy local timeouts.
+
+## Integration proposal for maintainers
+
+- Introduce distinct versioned offer/acknowledgment/renewal control models and
+  capability detection. Bind them to authenticated sender, peer, and session.
+  The simulator assumes an authenticated, correctly routed two-peer channel;
+  it does not implement cryptographic verification or adversarial input validation.
+- Keep legacy dialogue models and digests unchanged by default. A new opt-in
+  protocol would have its own digest. Do not add fields to existing application
+  messages without a migration decision.
+- Enforce the negotiated lease on both application send and receive paths,
+  reusing the local expiry guard concept from PR #942. This experiment models
+  control messages only; it does not dispatch application messages.
+- Decide how activity requests renewal. The prototype uses explicit renewals,
+  not independent idle resets on each message. Renewal timing, retry budgets,
+  and possible piggybacking need design and integration tests.
+- Define errors for expired/unknown sessions and transport failures. Never
+  silently reopen an old session. Do not automatically restart a dialogue whose
+  application side effects might already have occurred.
+- Decide whether fresh-session recovery is acceptable. Seamless resume would
+  require a separate authenticated recovery exchange and durable state design.
+- Add timeout-input validation (including nonfinite values), negotiated drift
+  assumptions, bounded session replay records and ACK caches, overload limits,
+  and crash/persistence fault tests before production use.
+- Decide unlimited-timeout semantics explicitly. This prototype rejects zero
+  and negative preferences instead of changing uAgents' existing zero behavior.
+
+## Result
+
+The experiment supplies a concrete, testable negotiation policy and exposes its
+failure cases. It is evidence for a design discussion, not grounds to close #413.
+Maintainer agreement on the control protocol and compatibility/recovery choices
+should precede a production integration PR.
+
+## Validation and acceptance gates
+
+The standalone suite contains 16 tests, including a 27-case clock-rate/delay
+matrix. It checks negotiation, successful renewal, lost and late acknowledgments,
+duplicate requests, stale/wrong-session responses, expiry, JSON restart recovery,
+and unsupported or silent peers. It also verifies the expected disagreements
+after acknowledgment loss and a remote restart. All tests are deterministic and
+use virtual time; there are no sleeps or live network calls.
+
+Before this can become a runtime PR:
+
+1. Agree on lease versus idle-timeout semantics, control-message schemas,
+   initiator authority, drift assumptions, and legacy/unlimited-timeout behavior.
+2. Integrate authenticated control messages and application send/receive guards
+   into two real uAgents, with versioned capability negotiation.
+3. Test both local dispatch and serialized transport with delayed, dropped,
+   duplicated and reordered control/application messages, including transport
+   failures, differing preferences, and mixed-version peers.
+4. Test process restart and durable storage failure; decide whether a fresh
+   dialogue is acceptable or implement an explicit recovery protocol.
+5. Define retry/resource limits and validate malformed/untrusted inputs. Run
+   the relevant context/protocol tests, full suite, and repository checks.
+
+The open design questions above are the review request for this draft. Passing
+the simulation is not evidence that these integration gates have been met.

--- a/proposals/dialogue-timeout/README.md
+++ b/proposals/dialogue-timeout/README.md
@@ -5,6 +5,18 @@ This standalone simulation explores the peer-synchronization part of
 It is not integrated with uAgents and does not change PR #942. No network,
 blockchain transactions, dependencies, or real agents are required.
 
+## Draft status and review material
+
+This is a design-review draft, not a merge-ready production fix. Maintainers
+have not approved the wire protocol and compatibility choices, and the model
+has not been integrated into real uAgents or exercised over their transports.
+Issue #413 must remain open for the peer-synchronization work.
+
+- [Test inventory and validation results](TESTING.md): every executed simulation
+  test, reproduction commands, limitations, and separate evidence from #942.
+- [Real-peer integration requirements](INTEGRATION.md): implementation decisions,
+  missing tests, and criteria for a production implementation.
+
 ## Relationship to the existing fix
 
 Issue #413 describes two problems: local expiry is not enforced by the dialogue
@@ -29,8 +41,6 @@ From this directory, using Python 3.10 or newer:
 python -m unittest -v
 python lease_simulation.py
 ```
-
-
 
 ## Proposed semantics
 

--- a/proposals/dialogue-timeout/TESTING.md
+++ b/proposals/dialogue-timeout/TESTING.md
@@ -1,0 +1,76 @@
+# Test inventory and validation
+
+## Scope and result
+
+The prototype suite passes all 16 unittest methods. One method additionally
+exercises 27 clock-rate/delay combinations; these are subcases, not 27 additional
+top-level tests. Tests run deterministically in memory with virtual time.
+
+These are simulated peer tests. They do not start real uAgents, exchange signed
+envelopes, use local dispatch or HTTP, or test durable filesystem recovery.
+Passing them supports the proposed model only, not production readiness.
+
+## Complete executed test inventory
+
+Names below are methods in `test_lease_simulation.py::LeaseTests`.
+
+| Test method | Behavior checked |
+| --- | --- |
+| `test_different_preferences_and_offsets` | Preferences of 60 and 30 seconds select 30 despite different clock offsets. |
+| `test_successful_renewal` | An acknowledged renewal extends both peers' active leases. |
+| `test_lost_ack_does_not_extend_initiator` | A lost acknowledgment leaves the initiator's old deadline unchanged while the responder may retain a longer lease. |
+| `test_delayed_initial_ack_is_rejected` | An initial acknowledgment arriving after the conservative deadline cannot activate the initiator. |
+| `test_late_renewal_ack_cannot_revive_expired_initiator` | Renewal acknowledgment after the old deadline does not revive the initiator. |
+| `test_expired_responder_rejects_renewal` | A renewal delivered after responder expiry is rejected. |
+| `test_duplicate_renewal_does_not_extend_deadline` | Replaying a renewal does not extend the responder deadline twice. |
+| `test_duplicate_offer_does_not_extend_deadline` | Replaying an initial offer does not reset the lease. |
+| `test_restart_rejects_replayed_session` | Simulated restart clears leases and rejects old-session offers and renewals. |
+| `test_stale_ack_does_not_acknowledge_new_renewal` | An old acknowledgment does not satisfy a pending newer renewal. |
+| `test_serialized_restart_requires_and_allows_fresh_negotiation` | JSON checkpoint/restore rejects an old session and permits negotiation of a fresh session. |
+| `test_remote_restart_is_not_instantly_known_by_initiator` | Explicitly demonstrates the limitation that the initiator cannot instantly detect responder restart. |
+| `test_wrong_session_ack_does_not_activate_peer` | An acknowledgment for another session does not activate the initiator. |
+| `test_unsupported_peer_explicitly_refuses` | A simulated protocol-aware unsupported peer refuses negotiation. |
+| `test_silent_old_peer_never_activates_initiator` | Absence of a reply never activates the initiator; this does not test a real legacy agent or a bounded retry loop. |
+| `test_conservative_deadlines_with_bounded_clock_drift` | Initiator real-time expiry is no later than responder expiry for 3 initiator rates x 3 responder rates x 3 delays, within the model's assumptions. |
+
+## Commands and other checks
+
+From the repository root with Python and Ruff available:
+
+```shell
+python -m unittest discover -s proposals/dialogue-timeout -v
+python proposals/dialogue-timeout/lease_simulation.py
+ruff check proposals/dialogue-timeout
+ruff format --check proposals/dialogue-timeout
+git diff --check
+```
+
+The unittest suite, demo, Ruff lint, Ruff formatting, and whitespace checks passed.
+The demo negotiates 30 seconds from preferences of 60 and 30 seconds, then drops
+a renewal acknowledgment. At virtual t=30 the initiator is inactive while the
+responder is still active. This disagreement is expected, not a claim of exact
+simultaneous expiry. The validation environment is Windows with the repository's
+existing Python virtual environment; no cross-platform test claim is made.
+
+## Separate evidence for the local fix
+
+PR #942 was validated separately with 119 passing pytest tests (including 12
+dialogue tests), targeted Ruff checks, and whitespace checks. Four selected
+regression cases failed when run against the prior upstream dialogue implementation.
+Its local test cases cover three cleanup frequencies, active/expired restart,
+unlimited and empty sessions, repeatable cleanup, expired inbound rejection,
+late handler sends during cleanup, active/unlimited sends, expired raw sends,
+expired-session reuse, and normal reply/history/deadline behavior.
+
+That result belongs to #942, not this independent prototype branch. The production
+suite was not rerun for the documentation-only update, and its passing result does
+not validate peer synchronization. GitHub CI results are separate from these local
+checks and are not asserted here.
+
+## Not yet tested
+
+Real two-uAgents integration; signed control envelopes; local and remote message
+dispatch; application messages crossing deadlines; mixed-version real peers;
+OS process crashes and atomic persistence; adversarial wire input; clock jumps;
+multi-peer concurrency; resource exhaustion; or production retry budgets.
+See [integration requirements](INTEGRATION.md) for the acceptance plan.

--- a/proposals/dialogue-timeout/lease_simulation.py
+++ b/proposals/dialogue-timeout/lease_simulation.py
@@ -1,0 +1,227 @@
+"""Deterministic, in-memory dialogue lease experiment. No network or SDK imports."""
+
+import heapq
+import json
+from dataclasses import dataclass, field
+from itertools import count
+
+
+@dataclass(frozen=True)
+class Message:
+    kind: str
+    session: str
+    seq: int
+    duration: float
+    version: int = 1
+
+
+@dataclass
+class Peer:
+    name: str
+    cap: float
+    offset: float = 0
+    rate: float = 1
+    drift_bound: float = 0.01
+    supported: bool = True
+    session: str | None = None
+    role: str | None = None
+    deadline: float | None = None
+    duration: float | None = None
+    pending: tuple[int, float] | None = None
+    seq: int = 0
+    seen: set[str] = field(default_factory=set)
+    responses: dict[int, Message] = field(default_factory=dict)
+    events: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not 0 <= self.drift_bound < 1:
+            raise ValueError("Invalid drift bound")
+        if not 1 - self.drift_bound <= self.rate <= 1 + self.drift_bound:
+            raise ValueError("Clock rate exceeds assumed drift bound")
+        if self.cap <= 0:
+            raise ValueError("Prototype requires a finite positive timeout")
+
+    def clock(self, now):
+        return self.offset + now * self.rate
+
+    def active(self, now):
+        return self.deadline is not None and self.clock(now) < self.deadline
+
+    def start(self, session, now):
+        if self.session is not None or session in self.seen:
+            raise ValueError("Use a fresh peer/session for a new dialogue")
+        self.session, self.role = session, "initiator"
+        self.seen.add(session)
+        self.pending = (0, self.clock(now))
+        return Message("offer", session, 0, self.cap)
+
+    def renew(self, now):
+        if self.role != "initiator" or not self.active(now) or self.pending:
+            raise ValueError(
+                "Renewal requires an active initiator with no pending request"
+            )
+        self.seq += 1
+        self.pending = (self.seq, self.clock(now))
+        return Message("renew", self.session, self.seq, self.duration)
+
+    def receive(self, msg, now):
+        """Return an optional reply; transport identity/authentication is assumed."""
+        if not self.supported or msg.version != 1:
+            self.events.append("unsupported")
+            return Message("unsupported", msg.session, msg.seq, 0)
+        if msg.kind == "unsupported":
+            if (
+                msg.session != self.session
+                or self.role != "initiator"
+                or not self.pending
+            ):
+                return None
+            self.events.append("negotiation refused: unsupported peer")
+            self.pending = None
+            self.deadline = None
+            return None
+        if msg.kind == "offer":
+            if msg.session == self.session and self.role == "responder":
+                # Retrying an offer must not move the lease's deadline.
+                return self.responses.get(0) if self.active(now) else None
+            if (
+                self.session is not None
+                or msg.session in self.seen
+                or msg.duration <= 0
+            ):
+                return None
+            self.session, self.role = msg.session, "responder"
+            self.seen.add(msg.session)
+            self.duration = min(msg.duration, self.cap)
+            self.deadline = self.clock(now) + self.duration * (1 + self.drift_bound)
+            reply = Message("ack", self.session, 0, self.duration)
+            self.responses[0] = reply
+            return reply
+        if msg.session != self.session:
+            return None
+        if msg.kind == "renew" and self.role == "responder":
+            if not self.active(now):
+                self.events.append("renewal rejected: expired")
+                return None
+            if msg.seq in self.responses:
+                return self.responses[msg.seq]
+            if msg.seq != self.seq + 1 or msg.duration != self.duration:
+                return None
+            self.seq = msg.seq
+            self.deadline = self.clock(now) + self.duration * (1 + self.drift_bound)
+            reply = Message("ack", self.session, msg.seq, self.duration)
+            self.responses[msg.seq] = reply
+            return reply
+        if msg.kind == "ack" and self.role == "initiator" and self.pending:
+            seq, sent_at = self.pending
+            if msg.seq != seq or not 0 < msg.duration <= self.cap:
+                return None
+            if self.duration is not None and msg.duration != self.duration:
+                return None
+            # An ACK must arrive before the conservative new deadline AND,
+            # for renewal, before the old acknowledged lease expires.
+            deadline = sent_at + msg.duration * (1 - self.drift_bound)
+            if self.clock(now) >= deadline or (seq > 0 and not self.active(now)):
+                self.events.append("ack rejected: late")
+                self.pending = None
+                return None
+            self.duration, self.deadline = msg.duration, deadline
+            self.pending = None
+        return None
+
+    def restart(self):
+        """Discard process-local clock leases; retain durable replay protection.
+
+        Production would persist the session ID before accepting the offer.
+        This prototype deliberately requires renegotiation after restart.
+        """
+        self.deadline = None
+        self.pending = None
+        self.responses.clear()
+        self.events.append("restart: session closed; fresh session required")
+
+    def checkpoint(self):
+        """Serialize only durable identity/configuration and retired session IDs."""
+        return json.dumps(
+            {
+                "name": self.name,
+                "cap": self.cap,
+                "offset": self.offset,
+                "rate": self.rate,
+                "drift_bound": self.drift_bound,
+                "supported": self.supported,
+                "seen": sorted(self.seen),
+            }
+        )
+
+    @classmethod
+    def restore(cls, checkpoint):
+        data = json.loads(checkpoint)
+        data["seen"] = set(data["seen"])
+        return cls(**data)
+
+
+class Simulation:
+    def __init__(self):
+        self.now = 0.0
+        self.queue = []
+        self.order = count()
+
+    def send(self, source, target, message, delay=0, reply_delay=0, drop_reply=False):
+        if delay < 0 or reply_delay < 0:
+            raise ValueError("Delays must be nonnegative")
+        heapq.heappush(
+            self.queue,
+            (
+                self.now + delay,
+                next(self.order),
+                source,
+                target,
+                message,
+                reply_delay,
+                drop_reply,
+            ),
+        )
+
+    def advance(self, until):
+        if until < self.now:
+            raise ValueError("Simulation time cannot go backwards")
+        while self.queue and self.queue[0][0] <= until:
+            when, _, source, target, message, reply_delay, drop = heapq.heappop(
+                self.queue
+            )
+            self.now = when
+            reply = target.receive(message, when)
+            if reply is not None and not drop:
+                # Replies are delivered once, without generating reply loops.
+                heapq.heappush(
+                    self.queue,
+                    (
+                        when + reply_delay,
+                        next(self.order),
+                        target,
+                        source,
+                        reply,
+                        0,
+                        True,
+                    ),
+                )
+        self.now = until
+
+
+if __name__ == "__main__":
+    sim = Simulation()
+    alice = Peer("Alice", 60, offset=3600)
+    bob = Peer("Bob", 30, offset=-7200)
+    sim.send(alice, bob, alice.start("demo", 0), delay=2, reply_delay=2)
+    sim.advance(4)
+    print(f"Negotiated duration: {alice.duration}s (preferences: 60s and 30s)")
+    print(f"At t=4s: Alice active={alice.active(4)}, Bob active={bob.active(4)}")
+    sim.advance(10)
+    sim.send(alice, bob, alice.renew(10), delay=1, drop_reply=True)
+    sim.advance(30)
+    print(
+        f"Lost renewal ACK, t=30s: Alice active={alice.active(30)}, "
+        f"Bob active={bob.active(30)}"
+    )
+    print("Alice stopped safely; exact simultaneous expiry is not guaranteed.")

--- a/proposals/dialogue-timeout/test_lease_simulation.py
+++ b/proposals/dialogue-timeout/test_lease_simulation.py
@@ -1,0 +1,142 @@
+import unittest
+
+from lease_simulation import Message, Peer, Simulation
+
+
+class LeaseTests(unittest.TestCase):
+    def pair(self, **kwargs):
+        sim = Simulation()
+        alice = Peer("Alice", 60, **kwargs)
+        bob = Peer("Bob", 30, offset=-5000)
+        sim.send(alice, bob, alice.start("session", 0), delay=1, reply_delay=1)
+        sim.advance(2)
+        return sim, alice, bob
+
+    def test_different_preferences_and_offsets(self):
+        _, alice, bob = self.pair(offset=90000)
+        self.assertEqual(alice.duration, 30)
+        self.assertEqual(bob.duration, 30)
+        self.assertTrue(alice.active(2) and bob.active(2))
+        self.assertFalse(alice.active(30))
+
+    def test_successful_renewal(self):
+        sim, alice, bob = self.pair()
+        sim.advance(10)
+        sim.send(alice, bob, alice.renew(10), delay=1, reply_delay=1)
+        sim.advance(12)
+        self.assertTrue(alice.active(35) and bob.active(35))
+
+    def test_lost_ack_does_not_extend_initiator(self):
+        sim, alice, bob = self.pair()
+        old = alice.deadline
+        sim.advance(10)
+        sim.send(alice, bob, alice.renew(10), delay=1, drop_reply=True)
+        sim.advance(30)
+        self.assertEqual(alice.deadline, old)
+        self.assertFalse(alice.active(30))
+        self.assertTrue(bob.active(30))  # Deliberate, documented disagreement.
+
+    def test_delayed_initial_ack_is_rejected(self):
+        sim = Simulation()
+        alice, bob = Peer("a", 10), Peer("b", 10)
+        sim.send(alice, bob, alice.start("s", 0), reply_delay=20)
+        sim.advance(20)
+        self.assertFalse(alice.active(20))
+        self.assertIn("ack rejected: late", alice.events)
+
+    def test_late_renewal_ack_cannot_revive_expired_initiator(self):
+        sim, alice, bob = self.pair()
+        sim.advance(20)
+        sim.send(alice, bob, alice.renew(20), reply_delay=11)
+        sim.advance(31)
+        self.assertFalse(alice.active(31))
+        self.assertIn("ack rejected: late", alice.events)
+
+    def test_expired_responder_rejects_renewal(self):
+        sim, alice, bob = self.pair()
+        sim.advance(20)
+        sim.send(alice, bob, alice.renew(20), delay=20)
+        sim.advance(40)
+        self.assertIn("renewal rejected: expired", bob.events)
+
+    def test_duplicate_renewal_does_not_extend_deadline(self):
+        sim, alice, bob = self.pair()
+        msg = alice.renew(10)
+        bob.receive(msg, 11)
+        deadline = bob.deadline
+        bob.receive(msg, 20)
+        self.assertEqual(bob.deadline, deadline)
+
+    def test_duplicate_offer_does_not_extend_deadline(self):
+        _, _, bob = self.pair()
+        deadline = bob.deadline
+        bob.receive(Message("offer", "session", 0, 60), 10)
+        self.assertEqual(bob.deadline, deadline)
+
+    def test_restart_rejects_replayed_session(self):
+        _, alice, bob = self.pair()
+        alice.restart()
+        bob.restart()
+        self.assertFalse(alice.active(3) or bob.active(3))
+        self.assertIsNone(bob.receive(Message("offer", "session", 0, 60), 3))
+        self.assertIsNone(bob.receive(Message("renew", "session", 1, 30), 3))
+
+    def test_stale_ack_does_not_acknowledge_new_renewal(self):
+        _, alice, _ = self.pair()
+        alice.renew(10)
+        alice.receive(Message("ack", "session", 0, 30), 11)
+        self.assertEqual(alice.pending[0], 1)
+
+    def test_serialized_restart_requires_and_allows_fresh_negotiation(self):
+        sim, alice, bob = self.pair()
+        alice = Peer.restore(alice.checkpoint())
+        bob = Peer.restore(bob.checkpoint())
+        self.assertFalse(alice.active(2) or bob.active(2))
+        self.assertIsNone(bob.receive(Message("offer", "session", 0, 60), 2))
+        sim.send(alice, bob, alice.start("new-session", 2), delay=1, reply_delay=1)
+        sim.advance(4)
+        self.assertTrue(alice.active(4) and bob.active(4))
+
+    def test_remote_restart_is_not_instantly_known_by_initiator(self):
+        _, alice, bob = self.pair()
+        bob.restart()
+        self.assertTrue(alice.active(3))
+        self.assertFalse(bob.active(3))
+        # A timeout protocol cannot guarantee knowledge of a remote crash.
+
+    def test_wrong_session_ack_does_not_activate_peer(self):
+        alice = Peer("a", 30)
+        alice.start("expected", 0)
+        alice.receive(Message("ack", "wrong", 0, 30), 1)
+        self.assertFalse(alice.active(1))
+
+    def test_unsupported_peer_explicitly_refuses(self):
+        sim = Simulation()
+        alice, bob = Peer("a", 30), Peer("b", 30, supported=False)
+        sim.send(alice, bob, alice.start("s", 0))
+        sim.advance(1)
+        self.assertFalse(alice.active(1))
+        self.assertIn("negotiation refused: unsupported peer", alice.events)
+
+    def test_silent_old_peer_never_activates_initiator(self):
+        alice = Peer("a", 30)
+        alice.start("s", 0)
+        self.assertFalse(alice.active(100))
+
+    def test_conservative_deadlines_with_bounded_clock_drift(self):
+        for a_rate in (0.99, 1, 1.01):
+            for b_rate in (0.99, 1, 1.01):
+                for delay in (0, 1, 5):
+                    with self.subTest(a=a_rate, b=b_rate, delay=delay):
+                        sim = Simulation()
+                        a = Peer("a", 30, offset=1000, rate=a_rate)
+                        b = Peer("b", 30, offset=-1000, rate=b_rate)
+                        sim.send(a, b, a.start("s", 0), delay=delay, reply_delay=delay)
+                        sim.advance(2 * delay)
+                        a_expiry = (a.deadline - a.offset) / a.rate
+                        b_expiry = (b.deadline - b.offset) / b.rate
+                        self.assertLessEqual(a_expiry, b_expiry + 1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed Changes

Dialogue peers currently choose their own local timeout, so one can discard a session while the other still considers it active. This draft proposes an opt-in negotiated lease and supplies a deterministic two-peer simulation for design review.

- Add a runnable, standard-library-only offer/acknowledgment/renewal simulation with different timeout preferences, clock offsets and bounded drift, virtual message delays, acknowledgment loss, duplicate handling, and serialized restart recovery.
- Add 16 tests, including 27 clock-rate/delay combinations within one test. Tests explicitly demonstrate that lost acknowledgments and remote restarts can leave peers with different views.
- Document the timing assumptions, conservative guarantee, compatibility choices, relationship to the local expiry fix, and acceptance gates for real uAgents integration.

There are no production runtime or existing protocol-schema changes. This is a proposal and experiment, not an applied peer-synchronization fix. The tests use simulated peers, not two real uAgents.

## Linked Issues

Related to #413; does not close it.

Companion to #942 (`fix: enforce local dialogue session expiry`). That PR implements local expiry guards and cleanup/restart corrections. This draft is based independently on `main` and addresses the remaining design questions around peer negotiation.

## Types of changes

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [x] Documentation update.
- [x] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/uAgents/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

### If applicable

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/updated the documentation (executed the script in `python/scripts/generate_api_docs.py`)

## Further comments

Validation applies to the standalone experiment: 16 unittest tests, the runnable demonstration, Ruff lint and formatting, and `git diff --check`. No production code is changed; the production suite was not rerun for this documentation/prototype branch. Documentation is handwritten Markdown; no API-doc generation was needed. The test checkbox denotes simulation behavior only.

The proposed duration is the smaller positive preference, and only acknowledged renewals extend the initiator's lease. With bounded clock drift and no responder restart/state loss, the initiator expires no later than the corresponding responder lease. This does not guarantee simultaneous expiry, remote-crash detection, or delivery of an application message sent near the deadline.

Review requested: lease versus idle semantics; initiator authority; versioned control messages; legacy and unlimited-timeout behavior; drift bounds; and fresh-session recovery versus seamless resume. Actual two-uAgents transport tests and runtime integration remain required before a production synchronization PR.

### Committed review documents

- [Proposal and current situation](https://github.com/ChrisWozniak/uAgents/blob/docs/dialogue-lease-prototype-413/proposals/dialogue-timeout/README.md)
- [Complete test inventory and validation](https://github.com/ChrisWozniak/uAgents/blob/docs/dialogue-lease-prototype-413/proposals/dialogue-timeout/TESTING.md): lists all 16 test methods, the 27 drift/delay subcases, commands, demonstrated limitations, and the separate results for #942.
- [Why this remains a draft and real-peer integration requirements](https://github.com/ChrisWozniak/uAgents/blob/docs/dialogue-lease-prototype-413/proposals/dialogue-timeout/INTEGRATION.md): design decisions, missing real-uAgents transport and recovery tests, and production acceptance criteria.

The documentation update was verified by rerunning all 16 simulation tests, the demo, Ruff lint/format checks, and whitespace checks. This draft is not ready to be represented as a production synchronization fix; #413 remains unresolved for that scope.
